### PR TITLE
remove email accountIntegration test case

### DIFF
--- a/tests/organization-owner/github/6-integrations/1.2.addIntegration.js
+++ b/tests/organization-owner/github/6-integrations/1.2.addIntegration.js
@@ -399,45 +399,6 @@ describe('Add Integrations',
           }
         );
 
-        it('Add Email AccountIntegration',
-          function (done) {
-            this.timeout(0);
-            var shippable = new Shippable(config.apiToken);
-            var name = "OrgOwner-Email";
-            var body = {
-              "masterDisplayName": "Email",
-              "masterIntegrationId": "55816ffb4d96360c000ec6f3",
-              "masterName": "Email",
-              "masterType": "notification",
-              "name": name,
-              "formJSONValues": [
-                {
-                  "label": "Email address",
-                  "value": "asdas"
-                }
-              ]
-            };
-            shippable.postAccountIntegration(body,
-              function(err,res) {
-                if (err) {
-                  isTestFailed = true;
-                  var testCase =
-                    util.format(
-                      '\n- [ ] %s: Add Email integration failed with error: %s',
-                      testSuiteDesc, err);
-                  testCaseErrors.push(testCase);
-                  assert.equal(err, null);
-                  return done();
-                } else {
-                  logger.debug('Added integration');
-                  accountIntegrations.push(res);
-                  return done();
-                }
-              }
-            );
-          }
-        );
-
         it('Add event trigger AccountIntegration',
           function (done) {
             this.timeout(0);

--- a/tests/organization-owner/github/6-integrations/1.2.getIntegrations.js
+++ b/tests/organization-owner/github/6-integrations/1.2.getIntegrations.js
@@ -272,37 +272,6 @@ describe(testSuite,
           }
         );
 
-        it('Edit Email Account Intgeration',
-          function (done) {
-            this.timeout(0);
-            var shippable = new Shippable(config.apiToken);
-
-            var body = _.findWhere(accountIntegrations,
-                         {name:"OrgOwner-Email"});
-            __setFormJSONValue(body.formJSONValues, 'Email address', 'test');
-
-            body.isValid = true;
-
-            shippable.putAccountIntegration(body.id, body,
-              function(err, res) {
-                if (err) {
-                  isTestFailed = true;
-                  var testCase =
-                    util.format(
-                      '\n- [ ] %s: Edit Email Intgeration failed with error: %s',
-                      testSuite, err);
-                  testCaseErrors.push(testCase);
-                  assert.equal(err, null);
-                  return done();
-                } else {
-                  logger.debug('Edited Integration');
-                  return done();
-                }
-              }
-            );
-          }
-        );
-
         it('Edit event trigger Account Intgeration',
           function (done) {
             this.timeout(0);


### PR DESCRIPTION
As we dont have `email accountIntegration` in prod or rc. Removing these test cases.

https://github.com/Shippable/pm/issues/7959