### PR TITLE
remove nconf.load in files

### DIFF
--- a/tests/organization-owner/github/5-projects/1.2.02.PauseAProject.js
+++ b/tests/organization-owner/github/5-projects/1.2.02.PauseAProject.js
@@ -27,9 +27,6 @@ describe('Pause Project',
         it('Pause Project',
           function (done) {
             this.timeout(0);
-            var pathToJson = process.cwd() + '/config.json';
-            nconf.argv().env().file({file: pathToJson});
-            nconf.load();
             projectId = nconf.get("shiptest-GITHUB_ORG_1:projectId");
             var shippable = new Shippable(config.apiToken);
             var update = {

--- a/tests/organization-owner/github/5-projects/1.2.03.ClearcacheProject.js
+++ b/tests/organization-owner/github/5-projects/1.2.03.ClearcacheProject.js
@@ -25,9 +25,6 @@ describe('Clear Cache',
         it('Clear Cache',
           function (done) {
             this.timeout(0);
-            var pathToJson = process.cwd() + '/config.json';
-            nconf.argv().env().file({file: pathToJson});
-            nconf.load();
             projectId = nconf.get("shiptest-GITHUB_ORG_1:projectId");
             var shippable = new Shippable(config.apiToken);
             var update = {

--- a/tests/organization-owner/github/5-projects/1.2.05.ResetAproject.js
+++ b/tests/organization-owner/github/5-projects/1.2.05.ResetAproject.js
@@ -25,9 +25,6 @@ describe('Reset in project settings page',
         it('Reset project from project settings pages',
           function (done) {
             this.timeout(0);
-            var pathToJson = process.cwd() + '/config.json';
-            nconf.argv().env().file({file: pathToJson});
-            nconf.load();
             var shippable = new Shippable(config.apiToken);
 
             projectId = nconf.get("shiptest-GITHUB_ORG_1:projectId");

--- a/tests/organization-owner/github/5-projects/1.2.06.RunsConfig.js
+++ b/tests/organization-owner/github/5-projects/1.2.06.RunsConfig.js
@@ -29,9 +29,6 @@ describe('Project RunsConfig',
         it('Get ProjectOwnerAccounts',
           function (done) {
             this.timeout(0);
-            var pathToJson = process.cwd() + '/config.json';
-            nconf.argv().env().file({file: pathToJson});
-            nconf.load();
             projectId = nconf.get('shiptest-GITHUB_ORG_1:projectId');
             shippable = new Shippable(config.apiToken);
             shippable.getProjectOwnerAccounts(projectId,
@@ -57,9 +54,6 @@ describe('Project RunsConfig',
         it('Set OwnerAccountIdWorkflow',
           function (done) {
             this.timeout(0);
-            var pathToJson = process.cwd() + '/config.json';
-            nconf.argv().env().file({file: pathToJson});
-            nconf.load();
             projectId = nconf.get('shiptest-GITHUB_ORG_1:projectId');
             accountId = nconf.get('shiptest-github-owner:accountId');
             var update = {
@@ -89,9 +83,6 @@ describe('Project RunsConfig',
         it('Automate Low Coverage Alert for value 10',
           function (done) {
             this.timeout(0);
-            var pathToJson = process.cwd() + '/config.json';
-            nconf.argv().env().file({file: pathToJson});
-            nconf.load();
             projectId = nconf.get('shiptest-GITHUB_ORG_1:projectId');
             var update = {
               propertyBag: {
@@ -209,9 +200,6 @@ describe('Project RunsConfig',
         it('Custom Timeout for valid value 10 mins (600000 ms)',
           function (done) {
             this.timeout(0);
-            var pathToJson = process.cwd() + '/config.json';
-            nconf.argv().env().file({file: pathToJson});
-            nconf.load();
             projectId = nconf.get("shiptest-GITHUB_ORG_1:projectId");
             var update = {
               propertyBag: {
@@ -356,9 +344,6 @@ describe('Project RunsConfig',
         it('Disable Run Parallel Jobs',
           function (done) {
             this.timeout(0);
-            var pathToJson = process.cwd() + '/config.json';
-            nconf.argv().env().file({file: pathToJson});
-            nconf.load();
             projectId = nconf.get('shiptest-GITHUB_ORG_1:projectId');
             var update = {
               propertyBag: {
@@ -415,9 +400,6 @@ describe('Project RunsConfig',
         it('Enable Consolidate Reports',
           function (done) {
             this.timeout(0);
-            var pathToJson = process.cwd() + '/config.json';
-            nconf.argv().env().file({file: pathToJson});
-            nconf.load();
             projectId = nconf.get('shiptest-GITHUB_ORG_1:projectId');
             var update = {
               consolidateReports: true
@@ -471,9 +453,6 @@ describe('Project RunsConfig',
         it('Enable PullRequestBuilds',
           function (done) {
             this.timeout(0);
-            var pathToJson = process.cwd() + '/config.json';
-            nconf.argv().env().file({file: pathToJson});
-            nconf.load();
             projectId = nconf.get('shiptest-GITHUB_ORG_1:projectId');
             var update = {
               propertyBag: {
@@ -530,9 +509,6 @@ describe('Project RunsConfig',
         it('Enable CommitBuilds',
           function (done) {
             this.timeout(0);
-            var pathToJson = process.cwd() + '/config.json';
-            nconf.argv().env().file({file: pathToJson});
-            nconf.load();
             projectId = nconf.get('shiptest-GITHUB_ORG_1:projectId');
             var update = {
               propertyBag: {
@@ -589,9 +565,6 @@ describe('Project RunsConfig',
         it('Enable TagBuilds',
           function (done) {
             this.timeout(0);
-            var pathToJson = process.cwd() + '/config.json';
-            nconf.argv().env().file({file: pathToJson});
-            nconf.load();
             projectId = nconf.get('shiptest-GITHUB_ORG_1:projectId');
             var update = {
               propertyBag: {
@@ -648,9 +621,6 @@ describe('Project RunsConfig',
         it('Clear ProjectTimeout',
           function (done) {
             this.timeout(0);
-            var pathToJson = process.cwd() + '/config.json';
-            nconf.argv().env().file({file: pathToJson});
-            nconf.load();
             projectId = nconf.get('shiptest-GITHUB_ORG_1:projectId');
             var update = {
               clearTimeoutMS: true
@@ -678,9 +648,6 @@ describe('Project RunsConfig',
         it('Enable Serialization',
           function (done) {
             this.timeout(0);
-            var pathToJson = process.cwd() + '/config.json';
-            nconf.argv().env().file({file: pathToJson});
-            nconf.load();
             projectId = nconf.get('shiptest-GITHUB_ORG_1:projectId');
             var update = {
               propertyBag: {
@@ -737,9 +704,6 @@ describe('Project RunsConfig',
         it('Enable ReleaseBuilds',
           function (done) {
             this.timeout(0);
-            var pathToJson = process.cwd() + '/config.json';
-            nconf.argv().env().file({file: pathToJson});
-            nconf.load();
             projectId = nconf.get('shiptest-GITHUB_ORG_1:projectId');
             var update = {
               propertyBag: {
@@ -796,9 +760,6 @@ describe('Project RunsConfig',
         it('Get ProjectsById',
           function (done) {
             this.timeout(0);
-            var pathToJson = process.cwd() + '/config.json';
-            nconf.argv().env().file({file: pathToJson});
-            nconf.load();
             shippable.getProjectById(projectId,
               function (err, proj) {
                 if (err) {

--- a/tests/organization-owner/github/5-projects/1.2.07.ProjectsDashBoard.js
+++ b/tests/organization-owner/github/5-projects/1.2.07.ProjectsDashBoard.js
@@ -24,9 +24,6 @@ describe('Projects Dashboard',
         it('Trigger new build request',
           function (done) {
             this.timeout(0);
-            var pathToJson = process.cwd() + '/config.json';
-            nconf.argv().env().file({file: pathToJson});
-            nconf.load();
             projectId = nconf.get('shiptest-GITHUB_ORG_1:projectId');
             shippable = new Shippable(global.config.apiToken);
             shippable.triggerNewBuildByProjectId(projectId, {},

--- a/tests/organization-owner/github/5-projects/1.2.08.ProjectHistory.js
+++ b/tests/organization-owner/github/5-projects/1.2.08.ProjectHistory.js
@@ -29,9 +29,6 @@ describe('Project History',
         it('Get ProjectsById',
           function (done) {
             this.timeout(0);
-            var pathToJson = process.cwd() + '/config.json';
-            nconf.argv().env().file({file: pathToJson});
-            nconf.load();
             projectId = nconf.get('shiptest-GITHUB_ORG_1:projectId');
             shippable = new Shippable(config.apiToken);
             shippable.getProjectById(projectId,

--- a/tests/organization-owner/github/5-projects/1.2.10.SubscriptionsHistory.js
+++ b/tests/organization-owner/github/5-projects/1.2.10.SubscriptionsHistory.js
@@ -30,9 +30,6 @@ describe('Subscription History',
         it('Get SubscriptionsById',
           function (done) {
             this.timeout(0);
-            var pathToJson = process.cwd() + '/config.json';
-            nconf.argv().env().file({file: pathToJson});
-            nconf.load();
             subscriptionId = nconf.get('shiptest-GITHUB_ORG_1:subscriptionId');
             shippable = new Shippable(config.apiToken);
             shippable.getSubscriptionById(subscriptionId,

--- a/tests/organization-owner/github/5-projects/1.2.11.Home.js
+++ b/tests/organization-owner/github/5-projects/1.2.11.Home.js
@@ -31,9 +31,6 @@ describe('Home Dashboard',
         it('Get ProjectAccounts',
           function (done) {
             this.timeout(0);
-            var pathToJson = process.cwd() + '/config.json';
-            nconf.argv().env().file({file: pathToJson});
-            nconf.load();
             accountId = nconf.get('shiptest-github-owner:accountId');
             shippable = new Shippable(global.config.apiToken);
             var query = util.format('accountIds=%s', accountId);

--- a/tests/organization-owner/github/5-projects/1.2.12.RunsConsole.js
+++ b/tests/organization-owner/github/5-projects/1.2.12.RunsConsole.js
@@ -27,9 +27,6 @@ describe('Runs Console',
         it('Get Jobs',
           function (done) {
             this.timeout(0);
-            var pathToJson = process.cwd() + '/config.json';
-            nconf.argv().env().file({file: pathToJson});
-            nconf.load();
             runId = nconf.get('shiptest-GITHUB_ORG_1:runId');
             var query = 'runIds=' + runId;
             shippable = new Shippable(config.apiToken);

--- a/tests/organization-owner/github/5-projects/1.2.13.RunTestReports.js
+++ b/tests/organization-owner/github/5-projects/1.2.13.RunTestReports.js
@@ -31,9 +31,6 @@ describe('Runs Tests',
         it('Get Jobs',
           function (done) {
             this.timeout(0);
-            var pathToJson = process.cwd() + '/config.json';
-            nconf.argv().env().file({file: pathToJson});
-            nconf.load();
             shippable = new Shippable(config.apiToken);
             runId = nconf.get("shiptest-GITHUB_ORG_1:runId");
             var query = util.format('runIds=%s', runId);

--- a/tests/organization-owner/github/5-projects/1.2.14.RunsScript.js
+++ b/tests/organization-owner/github/5-projects/1.2.14.RunsScript.js
@@ -31,9 +31,6 @@ describe('Runs Script',
         it('Get Jobs',
           function (done) {
             this.timeout(0);
-            var pathToJson = process.cwd() + '/config.json';
-            nconf.argv().env().file({file: pathToJson});
-            nconf.load();
             shippable = new Shippable(config.apiToken);
             runId = nconf.get('shiptest-GITHUB_ORG_1:runId');
             var query = util.format('runIds=%s', runId);

--- a/tests/organization-owner/github/5-projects/1.2.15.DisableProject.js
+++ b/tests/organization-owner/github/5-projects/1.2.15.DisableProject.js
@@ -27,9 +27,6 @@ describe('Disable Project',
         it('Disable Project',
           function (done) {
             this.timeout(0);
-            var pathToJson = process.cwd() + '/config.json';
-            nconf.argv().env().file({file: pathToJson});
-            nconf.load();
             var projectId = nconf.get("shiptest-GITHUB_ORG_1:projectId");
             var shippable = new Shippable(config.apiToken);
             var body = {


### PR DESCRIPTION
We are already doing it in [aa_setUp.js](https://github.com/Shippable/bat/blob/master/tests/organization-owner/github/1-accounts/1.2.aa_setUp.js#L11).
Not sure why did we add this again in individual files.

I have tested it locally. After removing.

```
deepika@deepika-ThinkPad-X250:~/Desktop/shippable/bat$ npm run test-organizationOwner

> BAT@0.0.1 test-organizationOwner /home/deepika/Desktop/shippable/bat
> ./node_modules/mocha/bin/mocha -S tests/organization-owner/github/**/*.js



  Setup for accounts
    ✓ Should start setup (114ms)

  Edit email with valid and invalid email address
    1.2.accounts_editEmail - Edit email in accounts page
      ✓ Edit email with valid email address (108ms)
      ✓ Edit email contains dot in the address field (95ms)
      ✓ Edit Email contains dot with subdomain (84ms)
      ✓ Plus sign is considered valid character (118ms)
      ✓ Quotes around email is considered valid (107ms)
      ✓ Digits in address are valid (108ms)
      ✓ Dash in domain name is valid (110ms)
      ✓ Underscore in the address field is valid (85ms)
      ✓ .name is valid Top Level Domain name (131ms)
      ✓ Dot in Top Level Domain name also considered valid (124ms)
      ✓ Unicode char as address (210ms)
      ✓ .web is a valid top level domain (79ms)
      ✓ Dash in address field is valid (65ms)
    1.2.accounts_editEmail - Edit email in accounts page
2017-03-15T05:53:04.150Z - warn: PUT call to http://localhost:50000/accounts/58c8d6b1e5f30f1a004fbbed? returned status 404 with error 404
      ✓ Missing @ sign and domain (56ms)
2017-03-15T05:53:04.192Z - warn: PUT call to http://localhost:50000/accounts/58c8d6b1e5f30f1a004fbbed? returned status 404 with error 404
      ✓ Domain is invalid IP address
2017-03-15T05:53:04.220Z - warn: PUT call to http://localhost:50000/accounts/58c8d6b1e5f30f1a004fbbed? returned status 404 with error 404
      ✓ Square bracket around IP address is considered invalid
2017-03-15T05:53:04.250Z - warn: PUT call to http://localhost:50000/accounts/58c8d6b1e5f30f1a004fbbed? returned status 404 with error 404
      ✓ Garbage
2017-03-15T05:53:04.294Z - warn: PUT call to http://localhost:50000/accounts/58c8d6b1e5f30f1a004fbbed? returned status 404 with error 404
      ✓ Missing username (41ms)
2017-03-15T05:53:04.318Z - warn: PUT call to http://localhost:50000/accounts/58c8d6b1e5f30f1a004fbbed? returned status 404 with error 404
      ✓ Encoded html within email is invalid
2017-03-15T05:53:04.361Z - warn: PUT call to http://localhost:50000/accounts/58c8d6b1e5f30f1a004fbbed? returned status 404 with error 404
      ✓ Missing @ (42ms)
2017-03-15T05:53:04.386Z - warn: PUT call to http://localhost:50000/accounts/58c8d6b1e5f30f1a004fbbed? returned status 404 with error 404
      ✓ Two @ sign
2017-03-15T05:53:04.428Z - warn: PUT call to http://localhost:50000/accounts/58c8d6b1e5f30f1a004fbbed? returned status 404 with error 404
      ✓ Leading dot in address is not allowed (43ms)
2017-03-15T05:53:04.467Z - warn: PUT call to http://localhost:50000/accounts/58c8d6b1e5f30f1a004fbbed? returned status 404 with error 404
      ✓ Trailing dot in address is not allowed (40ms)
2017-03-15T05:53:04.517Z - warn: PUT call to http://localhost:50000/accounts/58c8d6b1e5f30f1a004fbbed? returned status 404 with error 404
      ✓ Multiple dots (46ms)
2017-03-15T05:53:04.569Z - warn: PUT call to http://localhost:50000/accounts/58c8d6b1e5f30f1a004fbbed? returned status 404 with error 404
      ✓ Text followed email is not allowed (54ms)
2017-03-15T05:53:04.597Z - warn: PUT call to http://localhost:50000/accounts/58c8d6b1e5f30f1a004fbbed? returned status 404 with error 404
      ✓ Missing top level domain (.com/.net/.org/etc)
2017-03-15T05:53:04.631Z - warn: PUT call to http://localhost:50000/accounts/58c8d6b1e5f30f1a004fbbed? returned status 404 with error 404
      ✓ Leading dash in front of domain is invalid (60ms)
2017-03-15T05:53:04.718Z - warn: PUT call to http://localhost:50000/accounts/58c8d6b1e5f30f1a004fbbed? returned status 404 with error 404
      ✓ Invalid IP format (55ms)
2017-03-15T05:53:04.754Z - warn: PUT call to http://localhost:50000/accounts/58c8d6b1e5f30f1a004fbbed? returned status 404 with error 404
      ✓ Multiple dot in the domain portion is invalid
    Should run after above test suites
      ✓ Edit email with actual email address (72ms)
      ✓ Creating Github Issue if test cases failed

  1.2_sync_accountByid - Sync Account for organization owner
    ✓ Sync Account for organization owner (84ms)

  Add Tokens with different name
    1.2.accounts_AddToken - Add Tokens in account settings page
      ✓ Enter token name with 150 characters (97ms)
      ✓ Enter token name with less than 150 characters (86ms)
      ✓ Enter a - z; A - Z; (119ms)
      ✓ Enter numbers (93ms)
      ✓ Enter special characters (81ms)
      ✓ Enter Alphanumeric values (92ms)
      ✓ Enter the name with blank spaces (95ms)
      ✓ Enter special characters,numbers,alphabets (102ms)
    1.2.accounts_AddToken - Add Tokens in account settings page
2017-03-15T05:53:05.731Z - warn: POST call to http://localhost:50000/accountTokens returned status 404 with error 404
      ✓ Enter token name with more than 150 characters (46ms)
2017-03-15T05:53:05.873Z - warn: POST call to http://localhost:50000/accountTokens returned status 409 with error 409
      ✓ Enter the name already exists (141ms)
    Should run after above test suites
      ✓ Creating Github Issue if test cases failed

  1.2.API Tokens - ApiTokens
    Getting list of ApiTokens
      ✓ Get List of API Tokens
    delete ApiTokens
      ✓ delete ApiTokens (179ms)
    Create GitHub issue if failed
      ✓ Creating Github Issue if test cases failed

  1.2 - Account Cards
    Getting list of AccountCards
2017-03-15T05:53:07.504Z - warn: GET call to http://localhost:50000/accountCards? returned status 400 with error 400
      1) Get List of AccountCards
    delete AccountCards
      ✓ delete AccountCards
    Create GitHub issue if failed
      ✓ Creating Github Issue if test cases failed (1068ms)

  Edit email with valid and invalid email address in technical contact
    Get subscriptions
      ✓ Organization-Owner-github-getSubscription (56ms)
    1.2 - Edit technical contact in subscription settings page
      ✓ Edit email with valid email address (231ms)
      ✓ Edit email contains dot in the address field (221ms)
      ✓ Edit Email contains dot with subdomain (270ms)
      ✓ Plus sign is considered valid character (288ms)
      ✓ Quotes around email is considered valid (219ms)
      ✓ Digits in address are valid (219ms)
      ✓ Dash in domain name is valid (160ms)
      ✓ Underscore in the address field is valid (229ms)
      ✓ .name is valid Top Level Domain name (175ms)
      ✓ Dot in Top Level Domain name also considered valid (189ms)
      ✓ Unicode char as address (160ms)
      ✓ .web is a valid top level domain (144ms)
      ✓ Dash in address field is valid (152ms)
    1.2 - Edit technical contact in subscription settings page
2017-03-15T05:53:11.456Z - warn: PUT call to http://localhost:50000/subscriptions/58c8d6b5e5f30f1a004fbbf3 returned status 404 with error 404
      ✓ Missing @ sign and domain (128ms)
2017-03-15T05:53:11.479Z - warn: PUT call to http://localhost:50000/subscriptions/58c8d6b5e5f30f1a004fbbf3 returned status 404 with error 404
      ✓ Domain is invalid IP address
2017-03-15T05:53:11.504Z - warn: PUT call to http://localhost:50000/subscriptions/58c8d6b5e5f30f1a004fbbf3 returned status 404 with error 404
      ✓ Square bracket around IP address is considered invalid
2017-03-15T05:53:11.517Z - warn: PUT call to http://localhost:50000/subscriptions/58c8d6b5e5f30f1a004fbbf3 returned status 404 with error 404
      ✓ Garbage
2017-03-15T05:53:11.543Z - warn: PUT call to http://localhost:50000/subscriptions/58c8d6b5e5f30f1a004fbbf3 returned status 404 with error 404
      ✓ Missing username
2017-03-15T05:53:11.573Z - warn: PUT call to http://localhost:50000/subscriptions/58c8d6b5e5f30f1a004fbbf3 returned status 404 with error 404
      ✓ Encoded html within email is invalid
2017-03-15T05:53:11.585Z - warn: PUT call to http://localhost:50000/subscriptions/58c8d6b5e5f30f1a004fbbf3 returned status 404 with error 404
      ✓ Missing @
2017-03-15T05:53:11.607Z - warn: PUT call to http://localhost:50000/subscriptions/58c8d6b5e5f30f1a004fbbf3 returned status 404 with error 404
      ✓ Two @ sign
2017-03-15T05:53:11.628Z - warn: PUT call to http://localhost:50000/subscriptions/58c8d6b5e5f30f1a004fbbf3 returned status 404 with error 404
      ✓ Leading dot in address is not allowed
2017-03-15T05:53:11.643Z - warn: PUT call to http://localhost:50000/subscriptions/58c8d6b5e5f30f1a004fbbf3 returned status 404 with error 404
      ✓ Trailing dot in address is not allowed
2017-03-15T05:53:11.666Z - warn: PUT call to http://localhost:50000/subscriptions/58c8d6b5e5f30f1a004fbbf3 returned status 404 with error 404
      ✓ Multiple dots
2017-03-15T05:53:11.678Z - warn: PUT call to http://localhost:50000/subscriptions/58c8d6b5e5f30f1a004fbbf3 returned status 404 with error 404
      ✓ Text followed email is not allowed
2017-03-15T05:53:11.702Z - warn: PUT call to http://localhost:50000/subscriptions/58c8d6b5e5f30f1a004fbbf3 returned status 404 with error 404
      ✓ Missing top level domain (.com/.net/.org/etc)
2017-03-15T05:53:11.726Z - warn: PUT call to http://localhost:50000/subscriptions/58c8d6b5e5f30f1a004fbbf3 returned status 404 with error 404
      ✓ Leading dash in front of domain is invalid
2017-03-15T05:53:11.756Z - warn: PUT call to http://localhost:50000/subscriptions/58c8d6b5e5f30f1a004fbbf3 returned status 404 with error 404
      ✓ Invalid IP format
2017-03-15T05:53:11.766Z - warn: PUT call to http://localhost:50000/subscriptions/58c8d6b5e5f30f1a004fbbf3 returned status 404 with error 404
      ✓ Multiple dot in the domain portion is invalid
    Should run after above test suites
      ✓ Creating Github Issue if test cases failed

  Edit email with valid and invalid email address
    1.2- Edit Billing email in subcriptions page
      ✓ Organization-Owner-github-getSubscription
      ✓ Edit email with valid email address (112ms)
      ✓ Edit email contains dot in the address field (151ms)
      ✓ Edit Email contains dot with subdomain (156ms)
      ✓ Plus sign is considered valid character (133ms)
      ✓ Quotes around email is considered valid (131ms)
      ✓ Digits in address are valid (141ms)
      ✓ Dash in domain name is valid (132ms)
      ✓ Underscore in the address field is valid (115ms)
      ✓ .name is valid Top Level Domain name (103ms)
      ✓ Dot in Top Level Domain name also considered valid (130ms)
      ✓ Unicode char as address (99ms)
      ✓ .web is a valid top level domain (101ms)
      ✓ Dash in address field is valid (120ms)
    1.2- Edit Billing email in subcriptions page
2017-03-15T05:53:13.433Z - warn: PUT call to http://localhost:50000/subscriptions/58c8d6b5e5f30f1a004fbbf3 returned status 404 with error 404
      ✓ Missing @ sign and domain
2017-03-15T05:53:13.459Z - warn: PUT call to http://localhost:50000/subscriptions/58c8d6b5e5f30f1a004fbbf3 returned status 404 with error 404
      ✓ Domain is invalid IP address
2017-03-15T05:53:13.487Z - warn: PUT call to http://localhost:50000/subscriptions/58c8d6b5e5f30f1a004fbbf3 returned status 404 with error 404
      ✓ Square bracket around IP address is considered invalid
2017-03-15T05:53:13.508Z - warn: PUT call to http://localhost:50000/subscriptions/58c8d6b5e5f30f1a004fbbf3 returned status 404 with error 404
      ✓ Garbage
2017-03-15T05:53:13.525Z - warn: PUT call to http://localhost:50000/subscriptions/58c8d6b5e5f30f1a004fbbf3 returned status 404 with error 404
      ✓ Missing username
2017-03-15T05:53:13.543Z - warn: PUT call to http://localhost:50000/subscriptions/58c8d6b5e5f30f1a004fbbf3 returned status 404 with error 404
      ✓ Encoded html within email is invalid
2017-03-15T05:53:13.566Z - warn: PUT call to http://localhost:50000/subscriptions/58c8d6b5e5f30f1a004fbbf3 returned status 404 with error 404
      ✓ Missing @
2017-03-15T05:53:13.587Z - warn: PUT call to http://localhost:50000/subscriptions/58c8d6b5e5f30f1a004fbbf3 returned status 404 with error 404
      ✓ Two @ sign
2017-03-15T05:53:13.604Z - warn: PUT call to http://localhost:50000/subscriptions/58c8d6b5e5f30f1a004fbbf3 returned status 404 with error 404
      ✓ Leading dot in address is not allowed
2017-03-15T05:53:13.627Z - warn: PUT call to http://localhost:50000/subscriptions/58c8d6b5e5f30f1a004fbbf3 returned status 404 with error 404
      ✓ Trailing dot in address is not allowed
2017-03-15T05:53:13.639Z - warn: PUT call to http://localhost:50000/subscriptions/58c8d6b5e5f30f1a004fbbf3 returned status 404 with error 404
      ✓ Multiple dots
2017-03-15T05:53:13.666Z - warn: PUT call to http://localhost:50000/subscriptions/58c8d6b5e5f30f1a004fbbf3 returned status 404 with error 404
      ✓ Text followed email is not allowed
2017-03-15T05:53:13.690Z - warn: PUT call to http://localhost:50000/subscriptions/58c8d6b5e5f30f1a004fbbf3 returned status 404 with error 404
      ✓ Missing top level domain (.com/.net/.org/etc)
2017-03-15T05:53:13.707Z - warn: PUT call to http://localhost:50000/subscriptions/58c8d6b5e5f30f1a004fbbf3 returned status 404 with error 404
      ✓ Leading dash in front of domain is invalid
2017-03-15T05:53:13.726Z - warn: PUT call to http://localhost:50000/subscriptions/58c8d6b5e5f30f1a004fbbf3 returned status 404 with error 404
      ✓ Invalid IP format
2017-03-15T05:53:13.750Z - warn: PUT call to http://localhost:50000/subscriptions/58c8d6b5e5f30f1a004fbbf3 returned status 404 with error 404
      ✓ Multiple dot in the domain portion is invalid
    Should run after above test suites
      ✓ Creating Github Issue if test cases failed

  Reset in subscription settings page
    1.2 - Reset in subscription settings page
      ✓ Organization-Owner-github-getSubscription
      ✓ Reset subscription from subscription settings pages (1093ms)
    Should run after above test suites
      ✓ Creating Github Issue if test cases failed

  1.2 - subscription settings - encrypt and decrypt
    Encrypt and Decrypt
      ✓ Organization-Owner-github-getSubscription (51ms)
      ✓ Enter encrypt value with alphabets and encrypt (69ms)
      ✓ Enter encrypt value with numbers and encrypt (58ms)
      ✓ Enter encrypt value with alphanumeric and encrypt (57ms)
      ✓ Enter encrypt with special characters and encrypt (76ms)
      ✓ Enter encrypt value with blank spaces and encrypt (58ms)
      ✓ Encrypt value with special characters,numbers,alphabets and encrypt (56ms)
      ✓ Encrypt value with foo: fubu (57ms)
      ✓ Encrypt value with foo= fubu (81ms)
    Create GitHub issue if failed
      ✓ Creating Github Issue if test cases failed

  1.2 - Add a Resource
    Create Github subscriptionIntegration
      ✓ Organization-Owner-github-getSubscription (52ms)
      ✓ Get github AccountIntegartion (60ms)
      ✓ Add github subscriptionIntegration (126ms)
    Create New Resource
      ✓ Get SubscriptionIntegrations (57ms)
      ✓ Get Projects (46ms)
      ✓ Get Project Resources
      ✓ Get ProjectById (3073ms)
      ✓ Add a resource (8124ms)
      ✓ get resources (46ms)
    Should run after above test suites
      ✓ Creating Github Issue if test cases failed

  1.2 - Resource Modal
    Resource Modal Controller
      ✓ get syncRepo resource
      ✓ Get SubscriptionIntegrations (50ms)
      ✓ Get Versions By ResourceId (47ms)
    Should run after above test suites
      ✓ Creating Github Issue if test cases failed

  1.2 - Params Modal
    Resource Modal Controller
      ✓ get syncRepo resource
      ✓ Get Versions By ResourceId (48ms)
      ✓ post Version (206ms)
    Should run after above test suites
      ✓ Creating Github Issue if test cases failed

  1.2 - Pipelines Controller
    Resource Modal Controller
      ✓ Organization-Owner-github-getSubscription (48ms)
      ✓ Get Subscription By Id (45ms)
      ✓ get resources (52ms)
      ✓ get Job Dependencies (38ms)
      ✓ get Build Status By SubscriptionId (78ms)
      ✓ get Version By Id (54ms)
      ✓ get Resource By Id (45ms)
      ✓ get resources (50ms)
      ✓ get versions for each resource (71ms)
      ✓ Get Projects
      ✓ Get Inflight Builds
    Should run after above test suites
      ✓ Creating Github Issue if test cases failed

  1.2 - Job Modal
    Job Modal Controller
      ✓ Organization-Owner-github-getSubscription
      ✓ get resources
      ✓ get Builds By resourceId
      ✓ get Build By id
      ✓ get BuildJobs
      ✓ get builds
      ✓ get Versions for all builds
      ✓ trigger New Build By ResourceId (43ms)
      ✓ put Build By Id (85ms)
      ✓ get Build By Id
      ✓ pause Run Workflow (104ms)
      ✓ unPause Run Workflow (81ms)
    Should run after above test suites
      ✓ Creating Github Issue if test cases failed

  1.2 - Job Console
    Job Consoles Controller
      ✓ Organization-Owner-github-getSubscription (48ms)
      ✓ get resources
      ✓ get Builds By resourceId
      ✓ get BuildJobs
      ✓ get BuildJobConsoles By BuildJobId (43ms)
    Should run after above test suites
      ✓ Creating Github Issue if test cases failed

  1.2 - Job Trace 
    Job Trace Controller
      ✓ Organization-Owner-github-getSubscription
      ✓ Get resources (6187ms)
      ✓ get versions (52ms)
      ✓ get resources (41ms)
    Should run after above test suites
      ✓ Creating Github Issue if test cases failed

  1.2 - Delete Resource
    Delete Resource
      ✓ Organization-Owner-github-getSubscription (49ms)
      ✓ get resources (53ms)
      ✓ Get Builds (30171ms)
      ✓ soft delete resource (134ms)
      ✓ hard delete resource (1799ms)
      ✓ delete Github subscriptionIntegration (105ms)
    Should run after above test suites
      ✓ Creating Github Issue if test cases failed

  Enable Project
    1.2 - Enable Project
      ✓ Organization-Owner-github-getSubscription
      ✓ Get Projects (51ms)
      ✓ Enable Project (5795ms)
    Should run after above test suites
      ✓ Creating Github Issue if test cases failed

  Pause Project
    1.2 - Pause a Project
      ✓ Pause Project (89ms)
      ✓ Resume Project (70ms)
    Should run after above test suites
      ✓ Creating Github Issue if test cases failed

  Clear Cache
    1.2 - Clear cache
      ✓ Clear Cache
    Should run after above test suites
      ✓ Creating Github Issue if test cases failed

  1.2 - Project settings - encrypt and decrypt
    Encrypt and Decrypt
      ✓ Organization-Owner-github-getSubscription
      ✓ Enter encrypt value with alphabets and encrypt (73ms)
      ✓ Enter encrypt value with numbers and encrypt (55ms)
      ✓ Enter encrypt value with alphanumeric and encrypt (74ms)
      ✓ Enter encrypt with special characters and encrypt (74ms)
      ✓ Enter encrypt value with blank spaces and encrypt (62ms)
      ✓ Encrypt value with special characters,numbers,alphabets and encrypt (55ms)
      ✓ Encrypt value with foo: fubu (57ms)
      ✓ Encrypt value with foo= fubu (84ms)
    Create GitHub issue if failed
      ✓ Creating Github Issue if test cases failed

  Reset in project settings page
    1.2 - Reset in project settings page
      ✓ Reset project from project settings pages (3953ms)
    Should run after above test suites
      ✓ Creating Github Issue if test cases failed

  Project RunsConfig
    1.2 - Project RunsConfig
      ✓ Get ProjectOwnerAccounts (69ms)
      ✓ Set OwnerAccountIdWorkflow
      ✓ Automate Low Coverage Alert for value 10
      ✓ Automate Low Coverage Alert for value 50
      ✓ Automate Low Coverage Alert for value 99
      ✓ Automate Low Coverage Alert for value 40
      ✓ Custom Timeout for valid value 10 mins (600000 ms) (56ms)
      ✓ Custom Timeout for valid value 10.5 mins (630000 ms) (49ms)
2017-03-15T05:54:18.182Z - warn: PUT call to http://localhost:50000/projects/58c8d6b7e5f30f1a004fbc03 returned status 400 with error 400
      ✓ Custom Timeout for invalid value 10000000 ms (40ms)
2017-03-15T05:54:18.205Z - warn: PUT call to http://localhost:50000/projects/58c8d6b7e5f30f1a004fbc03 returned status 400 with error 400
      ✓ Custom Timeout for invalid value ee
2017-03-15T05:54:18.240Z - warn: PUT call to http://localhost:50000/projects/58c8d6b7e5f30f1a004fbc03 returned status 400 with error 400
      ✓ Custom Timeout for invalid value 0 ms
      ✓ Disable Run Parallel Jobs (41ms)
      ✓ Enable Run Parallel Jobs (45ms)
      ✓ Enable Consolidate Reports
      ✓ Disable Consolidate Reports (39ms)
      ✓ Enable PullRequestBuilds (40ms)
      ✓ Disable PullRequestBuilds
      ✓ Enable CommitBuilds (86ms)
      ✓ Disable CommitBuilds
      ✓ Enable TagBuilds
      ✓ Disable TagBuilds
      ✓ Clear ProjectTimeout
      ✓ Enable Serialization
      ✓ Disable Serialization (44ms)
      ✓ Enable ReleaseBuilds
      ✓ Disable ReleaseBuilds
      ✓ Get ProjectsById
      ✓ Add SerializedBranch
      ✓ Remove SerializedBranch
      ✓ SaveBranchFilter
      ✓ SaveRunFilter for commit only
      ✓ SaveRunFilter for commit and pull requests
    Should run after above test suites
      ✓ Creating Github Issue if test cases failed

  Projects Dashboard
    1.2 - Projects Dashboard
      ✓ Trigger new build request (3930ms)
      ✓ Get inflight runs
      ✓ Cancel run (67ms)
      ✓ Get branch run status (87ms)
      ✓ Get run by id (57ms)
    Should run after above test suites
      ✓ Creating Github Issue if test cases failed

  Project History
    1.2 - Project History
      ✓ Get ProjectsById (91ms)
      ✓ Get Runs (47ms)
      ✓ Trigger new build request (1816ms)
      ✓ Get RunsById (49ms)
      ✓ Delete Run (361ms)
      ✓ Trigger new build request (4030ms)
      ✓ Get JobStatesMap (56ms)
      ✓ Get Runs (83ms)
    Should run after above test suites
      ✓ Creating Github Issue if test cases failed

  Subscriptions Dashboard
    1.2 - Subscriptions Dashboard
      ✓ Get Projects (61ms)
      ✓ Get Run Status By SubscriptionId (167ms)
      ✓ Trigger New Build (3903ms)
      ✓ Get inflight runs (66ms)
      ✓ wireDeleteRunGetTop (65ms)
      ✓ Put buildById
      ✓ Cancel run (85ms)
      ✓ Get runById (82ms)
      ✓ Get Run Status By SubId (65ms)
    Should run after above test suites
      ✓ Creating Github Issue if test cases failed

  Subscription History
    1.2 - Subscription History
      ✓ Get SubscriptionsById
      ✓ Get ProjectsById
      ✓ Get Runs
      ✓ Trigger new build request (1685ms)
      ✓ Get RunsById (44ms)
      ✓ Delete Run (323ms)
    Should run after above test suites
      ✓ Creating Github Issue if test cases failed

  Home Dashboard
    1.2 - Home Dashboard
      ✓ Get ProjectAccounts
      ✓ Get Enabled Projects
      ✓ Get Provider
      ✓ Get Run Status By accountId (44ms)
      ✓ Get inflight runs
      ✓ Cancel run
      ✓ Get RunById
      ✓ Get Runs for runFilter for commit and pull requests
      ✓ Get Runs for runFilter for commit only
    Should run after above test suites
      ✓ Creating Github Issue if test cases failed

  Runs Console
    1.2 - Runs Console
      ✓ Get Jobs
      ✓ Get JobConsoles By JobId (57ms)
      ✓ Trigger New Build (3885ms)
      ✓ Get runById (46ms)
      ✓ Cancel run
    Should run after above test suites
      ✓ Creating Github Issue if test cases failed

  Runs Tests
    1.2 - Runs Tests
      ✓ Get Jobs (45ms)
      ✓ Get Job Test Reports
    Should run after above test suites
      ✓ Creating Github Issue if test cases failed

  Runs Script
    1.2 - Runs Script
      ✓ Get Jobs (44ms)
      ✓ Get Jobs Script (62ms)
    Should run after above test suites
      ✓ Creating Github Issue if test cases failed

  Disable Project
    1.2 - Disable Project
      ✓ Disable Project (3952ms)
    Should run after above test suites
      ✓ Creating Github Issue if test cases failed

  1.2 - Machine Images
    select Machine Images
      ✓ Get systemMachineImages
      ✓ Organization-Owner-github-getSubscription (70ms)
      ✓ put systemMachineImageId to subscriptions (189ms)
    Create GitHub issue if failed
      ✓ Creating Github Issue if test cases failed

  Add Integrations
    Get github Account Integration
      ✓ Organization-Owner-github-getSubscription
      ✓ Get github AccountIntegartion
    1.2 - Add Integrations
      ✓ Add Gitlab AccountIntegration (66ms)
      ✓ Add Amazon ECR AccountIntegration (61ms)
2017-03-15T05:54:45.115Z - warn: POST call to http://localhost:50000/accountIntegrations returned status 404 with error 404
      2) Add AWS AccountIntegration
      ✓ Add ACS AccountIntegration (81ms)
      ✓ Add bitbucket AccountIntegration (74ms)
      ✓ Add ddc AccountIntegration (77ms)
      ✓ Add docker AccountIntegration (68ms)
      ✓ Add event trigger AccountIntegration (62ms)
      ✓ Add gcr AccountIntegration (76ms)
      ✓ Add gke AccountIntegration (83ms)
      ✓ Add hipchat AccountIntegration (58ms)
      ✓ Add private docker registry AccountIntegration (56ms)
      ✓ Add generic webhook AccountIntegration (62ms)
      ✓ Add Slack AccountIntegration (55ms)
2017-03-15T05:54:45.897Z - warn: POST call to http://localhost:50000/accountIntegrations returned status 404 with error 404
      3) Add AWS_IAM AccountIntegration
      ✓ Add Docker Cloud AccountIntegration (123ms)
      ✓ Add Docker Trusted Registry AccountIntegration (82ms)
      ✓ Add Github Enterprise AccountIntegration (123ms)
      ✓ Add Joyent Triton Public Cloud AccountIntegration (144ms)
      ✓ Add PEM Key AccountIntegration (140ms)
      ✓ Add Quay.io AccountIntegration (132ms)
      ✓ Add SSH Key AccountIntegration (133ms)
    1.2 - Add Integrations
      ✓ Add subscriptionIntegrations (1244ms)
    Should run after above test suites
      ✓ Creating Github Issue if test cases failed (757ms)

  1.2 - Get Integrations
    Getting list of AccountIntegartions
      ✓ Get List of AccountIntegartions (75ms)
    Edit account Integrations
      ✓ Edit Gitlab Account Intgeration (101ms)
      4) Edit AWS Account Intgeration
      ✓ Edit Amazon ECR Account Intgeration (84ms)
      ✓ Edit ACS Account Intgeration (106ms)
      ✓ Edit bitbucket Account Intgeration (126ms)
      ✓ Edit ddc Account Intgeration (119ms)
      ✓ Edit docker Account Intgeration (92ms)
      ✓ Edit event trigger Account Intgeration (88ms)
      ✓ Edit gcr Account Intgeration (82ms)
      ✓ Edit gke Account Intgeration (107ms)
      ✓ Edit hipchat Account Intgeration (90ms)
      ✓ Edit private docker registry Account Intgeration (81ms)
      ✓ Edit generic webhook event trigger Account Intgeration (83ms)
      ✓ Edit slack Account Intgeration (76ms)
      5) Edit AWS_IAM Account Intgeration
      ✓ Edit Docker_Cloud Account Intgeration (99ms)
      ✓ Edit Docker_trusted_registry Account Intgeration (80ms)
      ✓ Edit Github-Enterprise Account Intgeration (103ms)
      ✓ Edit Joyent-Triton-Public-Cloud Account Intgeration (98ms)
      ✓ Edit PEM-Key Account Intgeration (79ms)
      ✓ Edit Quay.io Account Intgeration (84ms)
      ✓ Edit SSH-Key Account Intgeration (85ms)
    Getting the list of subscriptionIntegrations
      ✓ Get the list of subscriptionIntegrations (40ms)
    Edit subscription Integration
      ✓ Edit all subscription Intgerations (1073ms)
    delete AccountIntegrations With Dependencies
2017-03-15T05:54:52.291Z - warn: DELETE call to http://localhost:50000/accountIntegrations/58c8d726e5f30f1a004fbc43 returned status 400 with error 400
2017-03-15T05:54:52.293Z - warn: DELETE call to http://localhost:50000/accountIntegrations/58c8d726e5f30f1a004fbc42 returned status 400 with error 400
2017-03-15T05:54:52.304Z - warn: DELETE call to http://localhost:50000/accountIntegrations/58c8d726e5f30f1a004fbc41 returned status 400 with error 400
2017-03-15T05:54:52.316Z - warn: DELETE call to http://localhost:50000/accountIntegrations/58c8d726e5f30f1a004fbc3d returned status 400 with error 400
2017-03-15T05:54:52.337Z - warn: DELETE call to http://localhost:50000/accountIntegrations/58c8d725e5f30f1a004fbc3c returned status 400 with error 400
2017-03-15T05:54:52.350Z - warn: DELETE call to http://localhost:50000/accountIntegrations/58c8d725e5f30f1a004fbc3a returned status 400 with error 400
2017-03-15T05:54:52.351Z - warn: DELETE call to http://localhost:50000/accountIntegrations/58c8d726e5f30f1a004fbc40 returned status 400 with error 400
2017-03-15T05:54:52.352Z - warn: DELETE call to http://localhost:50000/accountIntegrations/58c8d726e5f30f1a004fbc3e returned status 400 with error 400
2017-03-15T05:54:52.364Z - warn: DELETE call to http://localhost:50000/accountIntegrations/58c8d725e5f30f1a004fbc39 returned status 400 with error 400
2017-03-15T05:54:52.375Z - warn: DELETE call to http://localhost:50000/accountIntegrations/58c8d725e5f30f1a004fbc38 returned status 400 with error 400
2017-03-15T05:54:52.376Z - warn: DELETE call to http://localhost:50000/accountIntegrations/58c8d725e5f30f1a004fbc37 returned status 400 with error 400
2017-03-15T05:54:52.384Z - warn: DELETE call to http://localhost:50000/accountIntegrations/58c8d725e5f30f1a004fbc36 returned status 400 with error 400
2017-03-15T05:54:52.386Z - warn: DELETE call to http://localhost:50000/accountIntegrations/58c8d725e5f30f1a004fbc35 returned status 400 with error 400
2017-03-15T05:54:52.401Z - warn: DELETE call to http://localhost:50000/accountIntegrations/58c8d725e5f30f1a004fbc34 returned status 400 with error 400
2017-03-15T05:54:52.406Z - warn: DELETE call to http://localhost:50000/accountIntegrations/58c8d725e5f30f1a004fbc33 returned status 400 with error 400
2017-03-15T05:54:52.408Z - warn: DELETE call to http://localhost:50000/accountIntegrations/58c8d725e5f30f1a004fbc32 returned status 400 with error 400
2017-03-15T05:54:52.409Z - warn: DELETE call to http://localhost:50000/accountIntegrations/58c8d725e5f30f1a004fbc31 returned status 400 with error 400
2017-03-15T05:54:52.410Z - warn: DELETE call to http://localhost:50000/accountIntegrations/58c8d725e5f30f1a004fbc30 returned status 400 with error 400
2017-03-15T05:54:52.413Z - warn: DELETE call to http://localhost:50000/accountIntegrations/58c8d725e5f30f1a004fbc2e returned status 400 with error 400
2017-03-15T05:54:52.415Z - warn: DELETE call to http://localhost:50000/accountIntegrations/58c8d725e5f30f1a004fbc2d returned status 400 with error 400
2017-03-15T05:54:52.416Z - warn: DELETE call to http://localhost:50000/accountIntegrations/58c8d6b1e5f30f1a004fbbef returned status 400 with error 400
      ✓ delete AccountIntegrations (573ms)
    Delete subscriptionIntegrations
      ✓ Delete SubscriptionIntegrations (1037ms)
    delete AccountIntegrations
      ✓ delete AccountIntegrations (678ms)
    Create GitHub issue if failed
      ✓ Creating Github Issue if test cases failed

```