### PR TITLE
remove selenium from package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -62,8 +62,5 @@
       "logger",
       "util"
     ]
-  },
-  "devDependencies": {
-    "selenium-webdriver": "^3.0.1"
   }
 }


### PR DESCRIPTION
We are not using selenium anywhere. Removing it from package.json as it is taking a lot of time to install selenium everytime we run `bvt`.

I have tested bat test cases locally after removing this.