### PR TITLE
standardize test cases

### DIFF
--- a/tests/deleteAccount.js
+++ b/tests/deleteAccount.js
@@ -44,6 +44,9 @@ describe(util.format('%s1 - %s', testSuiteNum, testSuiteDesc),
         }
         async.each(accountIds,
           function(accountObj, nextObj) {
+            if (!accountObj.id) return nextObj();
+            if (!accountObj.apiToken) return nextObj();
+
             var shippable = new Shippable(accountObj.apiToken);
             shippable.deleteAccountById(accountObj.id,
               function(err, res) {

--- a/tests/getAccounts.js
+++ b/tests/getAccounts.js
@@ -75,7 +75,13 @@ describe(util.format('%s1 - %s', testSuiteNum, testSuiteDesc),
                   logger.debug('res is::', util.inspect(res,{depth:null}));
                   if (res.status<200 || res.status>=299)
                     logger.warn('status is::',res.status);
-                  token.id = _.first(res).id;
+
+                  if (_.isEmpty(res)) {
+                    logger.warn('getAccounts returned no account which is ' +
+                      'not expected, hence skipping subsequent test cases');
+                    assert.equal(res, 1);
+                  } else
+                    token.id = _.first(res).id;
                   return nextToken();
                 }
               }

--- a/tests/getAccounts.js
+++ b/tests/getAccounts.js
@@ -79,7 +79,7 @@ describe(util.format('%s1 - %s', testSuiteNum, testSuiteDesc),
                   if (_.isEmpty(res)) {
                     logger.warn('getAccounts returned no account which is ' +
                       'not expected, hence skipping subsequent test cases');
-                    assert.equal(res, 1);
+                    assert.notEqual(res.length, 0);
                   } else
                     token.id = _.first(res).id;
                   return nextToken();

--- a/tests/organization-owner/github/1-accounts/1.2.accounts_editEmail.js
+++ b/tests/organization-owner/github/1-accounts/1.2.accounts_editEmail.js
@@ -15,6 +15,8 @@ var testSuite = util.format('%s.accounts_editEmail - %s', testSuiteNum,
 
 var isTestFailed = false;
 var testCaseErrors = [];
+var accountId = '';
+
 describe('Edit email with valid and invalid email address',
   function () {
 
@@ -25,8 +27,11 @@ describe('Edit email with valid and invalid email address',
           function (done) {
             this.timeout(0);
             var shippable = new Shippable(global.config.apiToken);
+            accountId = nconf.get('shiptest-github-owner:accountId');
+            if (!accountId) return done();
+
             shippable.putAccountById(
-              nconf.get('shiptest-github-owner:accountId'),
+              accountId,
               '', { defaultEmail : 'test@gmail.com' },
               function(err) {
                 if (err) {
@@ -50,9 +55,10 @@ describe('Edit email with valid and invalid email address',
           function (done) {
             this.timeout(0);
             var shippable = new Shippable(global.config.apiToken);
+            if (!accountId) return done();
 
             shippable.putAccountById(
-              nconf.get('shiptest-github-owner:accountId'),
+              accountId,
               '', { defaultEmail : 'test.testt@gmail.com' },
               function(err) {
                 if (err) {
@@ -76,9 +82,10 @@ describe('Edit email with valid and invalid email address',
           function (done) {
             this.timeout(0);
             var shippable = new Shippable(global.config.apiToken);
+            if (!accountId) return done();
 
             shippable.putAccountById(
-              nconf.get('shiptest-github-owner:accountId'),
+              accountId,
               '', { defaultEmail : 'test@google.co.in' },
               function(err) {
                 if (err) {
@@ -102,9 +109,10 @@ describe('Edit email with valid and invalid email address',
           function (done) {
             this.timeout(0);
             var shippable = new Shippable(global.config.apiToken);
+            if (!accountId) return done();
 
             shippable.putAccountById(
-              nconf.get('shiptest-github-owner:accountId'),
+              accountId,
               '', { defaultEmail : 'test+test@google.co.in' },
               function(err) {
                 if (err) {
@@ -128,9 +136,10 @@ describe('Edit email with valid and invalid email address',
           function (done) {
             this.timeout(0);
             var shippable = new Shippable(global.config.apiToken);
+            if (!accountId) return done();
 
             shippable.putAccountById(
-              nconf.get('shiptest-github-owner:accountId'),
+              accountId,
               '', { defaultEmail : '\"test"\@gmail.com' },
               function(err) {
                 if (err) {
@@ -154,9 +163,10 @@ describe('Edit email with valid and invalid email address',
           function (done) {
             this.timeout(0);
             var shippable = new Shippable(global.config.apiToken);
+            if (!accountId) return done();
 
             shippable.putAccountById(
-              nconf.get('shiptest-github-owner:accountId'),
+              accountId,
               '', { defaultEmail : 'test12345@gmail.com' },
               function(err) {
                 if (err) {
@@ -180,9 +190,10 @@ describe('Edit email with valid and invalid email address',
           function (done) {
             this.timeout(0);
             var shippable = new Shippable(global.config.apiToken);
+            if (!accountId) return done();
 
             shippable.putAccountById(
-              nconf.get('shiptest-github-owner:accountId'),
+              accountId,
               '', { defaultEmail : 'test12345@google-co.in' },
               function(err) {
                 if (err) {
@@ -206,9 +217,10 @@ describe('Edit email with valid and invalid email address',
           function (done) {
             this.timeout(0);
             var shippable = new Shippable(global.config.apiToken);
+            if (!accountId) return done();
 
             shippable.putAccountById(
-              nconf.get('shiptest-github-owner:accountId'),
+              accountId,
               '', { defaultEmail : 'test_12345@yahoo.in' },
               function(err) {
                 if (err) {
@@ -232,9 +244,10 @@ describe('Edit email with valid and invalid email address',
           function (done) {
             this.timeout(0);
             var shippable = new Shippable(global.config.apiToken);
+            if (!accountId) return done();
 
             shippable.putAccountById(
-              nconf.get('shiptest-github-owner:accountId'),
+              accountId,
               '', { defaultEmail : 'test_12345@rediff.mail' },
               function(err) {
                 if (err) {
@@ -258,9 +271,10 @@ describe('Edit email with valid and invalid email address',
           function (done) {
             this.timeout(0);
             var shippable = new Shippable(global.config.apiToken);
+            if (!accountId) return done();
 
             shippable.putAccountById(
-              nconf.get('shiptest-github-owner:accountId'),
+              accountId,
               '', { defaultEmail : 'test_1234@google.co.in' },
               function(err) {
                 if (err) {
@@ -284,9 +298,10 @@ describe('Edit email with valid and invalid email address',
           function (done) {
             this.timeout(0);
             var shippable = new Shippable(global.config.apiToken);
+            if (!accountId) return done();
 
             shippable.putAccountById(
-              nconf.get('shiptest-github-owner:accountId'),
+              accountId,
               '', { defaultEmail : 'あいうえお@domain.com' },
               function(err) {
                 if (err) {
@@ -310,9 +325,10 @@ describe('Edit email with valid and invalid email address',
           function (done) {
             this.timeout(0);
             var shippable = new Shippable(global.config.apiToken);
+            if (!accountId) return done();
 
             shippable.putAccountById(
-              nconf.get('shiptest-github-owner:accountId'),
+              accountId,
               '', { defaultEmail : 'email@domain.web' },
               function(err) {
                 if (err) {
@@ -336,9 +352,10 @@ describe('Edit email with valid and invalid email address',
           function (done) {
             this.timeout(0);
             var shippable = new Shippable(global.config.apiToken);
+            if (!accountId) return done();
 
             shippable.putAccountById(
-              nconf.get('shiptest-github-owner:accountId'),
+              accountId,
               '', { defaultEmail : 'test-1234@google.co.in' },
               function(err) {
                 if (err) {
@@ -368,9 +385,10 @@ describe('Edit email with valid and invalid email address',
           function (done) {
             this.timeout(0);
             var shippable = new Shippable(global.config.apiToken);
+            if (!accountId) return done();
 
             shippable.putAccountById(
-              nconf.get('shiptest-github-owner:accountId'),
+              accountId,
               '', { defaultEmail : 'plainaddress' },
               function(err) {
                 if (err) {
@@ -396,9 +414,10 @@ describe('Edit email with valid and invalid email address',
           function (done) {
             this.timeout(0);
             var shippable = new Shippable(global.config.apiToken);
+            if (!accountId) return done();
 
             shippable.putAccountById(
-              nconf.get('shiptest-github-owner:accountId'),
+              accountId,
               '', { defaultEmail : 'test+testing@123.123.123.123' },
               function(err) {
                 if (err) {
@@ -425,9 +444,10 @@ describe('Edit email with valid and invalid email address',
           function (done) {
             this.timeout(0);
             var shippable = new Shippable(global.config.apiToken);
+            if (!accountId) return done();
 
             shippable.putAccountById(
-              nconf.get('shiptest-github-owner:accountId'),
+              accountId,
               '', { defaultEmail : 'test+testing@[123.123.123.123]' },
               function(err) {
                 if (err) {
@@ -455,9 +475,10 @@ describe('Edit email with valid and invalid email address',
           function (done) {
             this.timeout(0);
             var shippable = new Shippable(global.config.apiToken);
+            if (!accountId) return done();
 
             shippable.putAccountById(
-              nconf.get('shiptest-github-owner:accountId'),
+              accountId,
               '', { defaultEmail : '#@%^%#$@#$@#.com' },
               function(err) {
                 if (err) {
@@ -482,9 +503,10 @@ describe('Edit email with valid and invalid email address',
           function (done) {
             this.timeout(0);
             var shippable = new Shippable(global.config.apiToken);
+            if (!accountId) return done();
 
             shippable.putAccountById(
-              nconf.get('shiptest-github-owner:accountId'),
+              accountId,
               '', { defaultEmail : '@domain.com' },
               function(err) {
                 if (err) {
@@ -509,9 +531,10 @@ describe('Edit email with valid and invalid email address',
           function (done) {
             this.timeout(0);
             var shippable = new Shippable(global.config.apiToken);
+            if (!accountId) return done();
 
             shippable.putAccountById(
-              nconf.get('shiptest-github-owner:accountId'),
+              accountId,
               '', { defaultEmail : 'Joe Smith <email@domain.com>' },
               function(err) {
                 if (err) {
@@ -537,9 +560,10 @@ describe('Edit email with valid and invalid email address',
           function (done) {
             this.timeout(0);
             var shippable = new Shippable(global.config.apiToken);
+            if (!accountId) return done();
 
             shippable.putAccountById(
-              nconf.get('shiptest-github-owner:accountId'),
+              accountId,
               '', { defaultEmail : 'email.domain.com' },
               function(err) {
                 if (err) {
@@ -564,9 +588,10 @@ describe('Edit email with valid and invalid email address',
           function (done) {
             this.timeout(0);
             var shippable = new Shippable(global.config.apiToken);
+            if (!accountId) return done();
 
             shippable.putAccountById(
-              nconf.get('shiptest-github-owner:accountId'),
+              accountId,
               '', { defaultEmail : 'email@domain@domain.com' },
               function(err) {
                 if (err) {
@@ -592,9 +617,10 @@ describe('Edit email with valid and invalid email address',
           function (done) {
             this.timeout(0);
             var shippable = new Shippable(global.config.apiToken);
+            if (!accountId) return done();
 
             shippable.putAccountById(
-              nconf.get('shiptest-github-owner:accountId'),
+              accountId,
               '', { defaultEmail : '.email@domain.com' },
               function(err) {
                 if (err) {
@@ -619,9 +645,10 @@ describe('Edit email with valid and invalid email address',
           function (done) {
             this.timeout(0);
             var shippable = new Shippable(global.config.apiToken);
+            if (!accountId) return done();
 
             shippable.putAccountById(
-              nconf.get('shiptest-github-owner:accountId'),
+              accountId,
               '', { defaultEmail : 'email.@domain.com' },
               function(err) {
                 if (err) {
@@ -646,9 +673,10 @@ describe('Edit email with valid and invalid email address',
           function (done) {
             this.timeout(0);
             var shippable = new Shippable(global.config.apiToken);
+            if (!accountId) return done();
 
             shippable.putAccountById(
-              nconf.get('shiptest-github-owner:accountId'),
+              accountId,
               '', { defaultEmail : 'email..email@domain.com' },
               function(err) {
                 if (err) {
@@ -674,9 +702,10 @@ describe('Edit email with valid and invalid email address',
           function (done) {
             this.timeout(0);
             var shippable = new Shippable(global.config.apiToken);
+            if (!accountId) return done();
 
             shippable.putAccountById(
-              nconf.get('shiptest-github-owner:accountId'),
+              accountId,
               '', { defaultEmail : 'email@domain.com (Joe Smith)' },
               function(err) {
                 if (err) {
@@ -702,9 +731,10 @@ describe('Edit email with valid and invalid email address',
           function (done) {
             this.timeout(0);
             var shippable = new Shippable(global.config.apiToken);
+            if (!accountId) return done();
 
             shippable.putAccountById(
-              nconf.get('shiptest-github-owner:accountId'),
+              accountId,
               '', { defaultEmail : 'email@domain' },
               function(err) {
                 if (err) {
@@ -729,9 +759,10 @@ describe('Edit email with valid and invalid email address',
           function (done) {
             this.timeout(0);
             var shippable = new Shippable(global.config.apiToken);
+            if (!accountId) return done();
 
             shippable.putAccountById(
-              nconf.get('shiptest-github-owner:accountId'),
+              accountId,
               '', { defaultEmail : 'email@-domain.com' },
               function(err) {
                 if (err) {
@@ -756,9 +787,10 @@ describe('Edit email with valid and invalid email address',
           function (done) {
             this.timeout(0);
             var shippable = new Shippable(global.config.apiToken);
+            if (!accountId) return done();
 
             shippable.putAccountById(
-              nconf.get('shiptest-github-owner:accountId'),
+              accountId,
               '', { defaultEmail : 'email@111.222.333.44444' },
               function(err) {
                 if (err) {
@@ -784,9 +816,10 @@ describe('Edit email with valid and invalid email address',
           function (done) {
             this.timeout(0);
             var shippable = new Shippable(global.config.apiToken);
+            if (!accountId) return done();
 
             shippable.putAccountById(
-              nconf.get('shiptest-github-owner:accountId'),
+              accountId,
               '', { defaultEmail : 'email@domain..com' },
               function(err) {
                 if (err) {
@@ -816,9 +849,10 @@ describe('Edit email with valid and invalid email address',
           function (done) {
             this.timeout(0);
             var shippable = new Shippable(global.config.apiToken);
+            if (!accountId) return done();
 
             shippable.putAccountById(
-              nconf.get('shiptest-github-owner:accountId'),
+              accountId,
               '', { defaultEmail : 'shippabletowner+sub-o-org-o@gmail.com' },
               function(err) {
                 if (err) {

--- a/tests/organization-owner/github/1-accounts/1.2.accounts_sync.js
+++ b/tests/organization-owner/github/1-accounts/1.2.accounts_sync.js
@@ -12,6 +12,7 @@ var Shippable = require('../../../../_common/shippable/Adapter.js');
 
 var testSuite = util.format('%s2_sync_accountByid - %s',
                   testSuiteNum, testSuiteDesc);
+var accountId = '';
 
 describe(testSuite,
   function () {
@@ -20,8 +21,11 @@ describe(testSuite,
       function (done) {
         this.timeout(0);
         var shippable = new Shippable(config.apiToken);
+        accountId = nconf.get("shiptest-github-owner:accountId");
+        if (!accountId) return done();
+
         shippable.forceSyncAccountById(
-          nconf.get("shiptest-github-owner:accountId"),
+          accountId,
           function(err, res) {
             if (err) {
               var bag = {

--- a/tests/organization-owner/github/2-apiTokens/1.2.apiTokens_addToken.js
+++ b/tests/organization-owner/github/2-apiTokens/1.2.apiTokens_addToken.js
@@ -24,6 +24,8 @@ describe('Add Tokens with different name',
           function (done) {
             this.timeout(0);
             var shippable = new Shippable(config.apiToken);
+            if (!ownerAccountId) return done();
+
             var name = "Q6sW4LKREx20/Zw0g5Mpr6gJeZWzIsu2f6t3jJ4/sDGVu7PMWqFD" +
                          "v4KAGF97Tc9BE/5/LJ+D5SVSdHdY2oe7cwQrblqWA79riC8yS1c" +
                          "6Le27bGMjoqBSs7Opdd99C+SwdS1G1KDzq39eKXhXyoIM7q";
@@ -50,6 +52,8 @@ describe('Add Tokens with different name',
           function (done) {
             this.timeout(0);
             var shippable = new Shippable(config.apiToken);
+            if (!ownerAccountId) return done();
+
             var name = "Q6sW4LKREx20/Zw0g5Mpr6gJeZWzIsu2f6t3jJ4/sDGVu7PMWqFDv" +
                          "4KAGF97Tc9BE/5/LJ+D5SVSdHdY2oe7cwQrblqWA79riC8yS1c6" +
                          "Le27bGMjoqBSs7Opdd99C+SwdS1G1KDzq39eKX";
@@ -76,6 +80,8 @@ describe('Add Tokens with different name',
           function (done) {
             this.timeout(0);
             var shippable = new Shippable(config.apiToken);
+            if (!ownerAccountId) return done();
+
             var name = "abcABC";
             shippable.postAccountTokens(name, ownerAccountId,
               function(err) {
@@ -100,6 +106,8 @@ describe('Add Tokens with different name',
           function (done) {
             this.timeout(0);
             var shippable = new Shippable(config.apiToken);
+            if (!ownerAccountId) return done();
+
             var name = "1234567890";
             shippable.postAccountTokens(name, ownerAccountId,
               function(err) {
@@ -125,6 +133,8 @@ describe('Add Tokens with different name',
           function (done) {
             this.timeout(0);
             var shippable = new Shippable(config.apiToken);
+            if (!ownerAccountId) return done();
+
             var name = "!@#$%^&()";
             shippable.postAccountTokens(name, ownerAccountId,
               function(err) {
@@ -150,6 +160,8 @@ describe('Add Tokens with different name',
           function (done) {
             this.timeout(0);
             var shippable = new Shippable(config.apiToken);
+            if (!ownerAccountId) return done();
+
             var name = "12345678qwertyuio";
             shippable.postAccountTokens(name, ownerAccountId,
               function(err) {
@@ -175,6 +187,8 @@ describe('Add Tokens with different name',
           function (done) {
             this.timeout(0);
             var shippable = new Shippable(config.apiToken);
+            if (!ownerAccountId) return done();
+
             var name = "  aa    bb  ccc";
             shippable.postAccountTokens(name, ownerAccountId,
               function(err) {
@@ -200,6 +214,8 @@ describe('Add Tokens with different name',
           function (done) {
             this.timeout(0);
             var shippable = new Shippable(config.apiToken);
+            if (!ownerAccountId) return done();
+
             var name = "@#test&*(123";
             shippable.postAccountTokens(name, ownerAccountId,
               function(err) {
@@ -230,6 +246,8 @@ describe('Add Tokens with different name',
           function (done) {
             this.timeout(0);
             var shippable = new Shippable(config.apiToken);
+            if (!ownerAccountId) return done();
+
             var name = "Q6sW4LKREx20/Zw0g5Mpr6gJeZWzIsu2f6t3jJ4/sDGVu7PMWqFD" +
                        "v4KAGF97Tc9BE/5/LJ+D5SVSdHdY2oe7cwQrblqWA79riC8yS1c6L" +
                        "e27bGMjoqBSs7Opdd99C+SwdS1G1KDzq39eKXhXyoIM7q123456";
@@ -257,6 +275,8 @@ describe('Add Tokens with different name',
           function (done) {
             this.timeout(0);
             var shippable = new Shippable(config.apiToken);
+            if (!ownerAccountId) return done();
+
             var name = "abcABC";
             shippable.postAccountTokens(name, ownerAccountId,
               function(err) {

--- a/tests/organization-owner/github/2-apiTokens/1.2.apiTokens_getTokens.js
+++ b/tests/organization-owner/github/2-apiTokens/1.2.apiTokens_getTokens.js
@@ -60,6 +60,8 @@ describe(testSuite,
             this.timeout(0);
             var shippable = new Shippable(config.apiToken);
 
+            if (_.isEmpty(apiTokenIds)) return done();
+
             async.each(apiTokenIds,
               function(tokenId, nextTokenId) {
                 shippable.deleteAccountToken(tokenId,

--- a/tests/organization-owner/github/3-accountCards/1.2.getAccountCards.js
+++ b/tests/organization-owner/github/3-accountCards/1.2.getAccountCards.js
@@ -61,6 +61,8 @@ describe(testSuite,
             this.timeout(0);
             var shippable = new Shippable(config.apiToken);
 
+            if (_.isEmpty(accountCardIds)) return done();
+
             async.each(accountCardIds,
               function(accountCardId, nextAccountCardId) {
                 shippable.deleteAccountCardById(accountCardId,

--- a/tests/organization-owner/github/4-subscriptions/1.2.1.technical-email-edit.js
+++ b/tests/organization-owner/github/4-subscriptions/1.2.1.technical-email-edit.js
@@ -43,10 +43,11 @@ describe('Edit email with valid and invalid email address in technical contact',
                   if (subscriptions.status<200 || subscriptions.status>=299)
                     logger.warn("status is::",subscriptions.status);
 
-                  if (_.isEmpty(subscriptions))
+                  if (_.isEmpty(subscriptions)) {
                     logger.warn('No subscriptions found, skipping subsequent ' +
                       'testcases');
-                  else
+                    assert.equal(subscriptions, 1);
+                  } else
                     subscriptionId = _.first(subscriptions).id;
 
                   return done();

--- a/tests/organization-owner/github/4-subscriptions/1.2.1.technical-email-edit.js
+++ b/tests/organization-owner/github/4-subscriptions/1.2.1.technical-email-edit.js
@@ -46,7 +46,7 @@ describe('Edit email with valid and invalid email address in technical contact',
                   if (_.isEmpty(subscriptions)) {
                     logger.warn('No subscriptions found, skipping subsequent ' +
                       'testcases');
-                    assert.equal(subscriptions, 1);
+                    assert.notEqual(subscriptions.length, 0);
                   } else
                     subscriptionId = _.first(subscriptions).id;
 

--- a/tests/organization-owner/github/4-subscriptions/1.2.2.billing-email-edit.js
+++ b/tests/organization-owner/github/4-subscriptions/1.2.2.billing-email-edit.js
@@ -43,10 +43,11 @@ describe('Edit email with valid and invalid email address',
                   if (subscriptions.status<200 || subscriptions.status>=299)
                     logger.warn("status is::",subscriptions.status);
 
-                  if (_.isEmpty(subscriptions))
+                  if (_.isEmpty(subscriptions)) {
                     logger.warn('No subscriptions found, skipping subsequent ' +
                       'testcases');
-                  else
+                    assert.equal(subscriptions, 1);
+                  } else
                     subscriptionId = _.first(subscriptions).id;
 
                   return done();

--- a/tests/organization-owner/github/4-subscriptions/1.2.2.billing-email-edit.js
+++ b/tests/organization-owner/github/4-subscriptions/1.2.2.billing-email-edit.js
@@ -46,7 +46,7 @@ describe('Edit email with valid and invalid email address',
                   if (_.isEmpty(subscriptions)) {
                     logger.warn('No subscriptions found, skipping subsequent ' +
                       'testcases');
-                    assert.equal(subscriptions, 1);
+                    assert.notEqual(subscriptions.length, 0);
                   } else
                     subscriptionId = _.first(subscriptions).id;
 

--- a/tests/organization-owner/github/4-subscriptions/1.2.3.resetSubscription.js
+++ b/tests/organization-owner/github/4-subscriptions/1.2.3.resetSubscription.js
@@ -46,7 +46,7 @@ describe('Reset in subscription settings page',
                   if (_.isEmpty(subscriptions)) {
                     logger.warn('No subscriptions found, skipping subsequent ' +
                       'testcases');
-                    assert.equal(subscriptions, 1);
+                    assert.notEqual(subscriptions.length, 0);
                   } else
                     subscriptionId = _.first(subscriptions).id;
 

--- a/tests/organization-owner/github/4-subscriptions/1.2.3.resetSubscription.js
+++ b/tests/organization-owner/github/4-subscriptions/1.2.3.resetSubscription.js
@@ -43,10 +43,11 @@ describe('Reset in subscription settings page',
                   if (subscriptions.status<200 || subscriptions.status>=299)
                     logger.warn("status is::",subscriptions.status);
 
-                  if (_.isEmpty(subscriptions))
+                  if (_.isEmpty(subscriptions)) {
                     logger.warn('No subscriptions found, skipping subsequent ' +
                       'testcases');
-                  else
+                    assert.equal(subscriptions, 1);
+                  } else
                     subscriptionId = _.first(subscriptions).id;
 
                   return done();

--- a/tests/organization-owner/github/4-subscriptions/1.2.4.Encrypt.js
+++ b/tests/organization-owner/github/4-subscriptions/1.2.4.Encrypt.js
@@ -42,10 +42,11 @@ describe(testSuite,
                   if (subscriptions.status<200 || subscriptions.status>=299)
                     logger.warn("status is::",subscriptions.status);
 
-                  if (_.isEmpty(subscriptions))
+                  if (_.isEmpty(subscriptions)) {
                     logger.warn('No subscriptions found, skipping subsequent ' +
                       'testcases');
-                  else
+                    assert.equal(subscriptions, 1);
+                  } else
                     subscriptionId = _.first(subscriptions).id;
 
                   return done();

--- a/tests/organization-owner/github/4-subscriptions/1.2.4.Encrypt.js
+++ b/tests/organization-owner/github/4-subscriptions/1.2.4.Encrypt.js
@@ -45,7 +45,7 @@ describe(testSuite,
                   if (_.isEmpty(subscriptions)) {
                     logger.warn('No subscriptions found, skipping subsequent ' +
                       'testcases');
-                    assert.equal(subscriptions, 1);
+                    assert.notEqual(subscriptions.length, 0);
                   } else
                     subscriptionId = _.first(subscriptions).id;
 

--- a/tests/organization-owner/github/4-subscriptions/1.2.5.AddResource.js
+++ b/tests/organization-owner/github/4-subscriptions/1.2.5.AddResource.js
@@ -54,7 +54,7 @@ describe(testSuite,
                   if (_.isEmpty(subscriptions)) {
                     logger.warn('No subscriptions found, skipping subsequent ' +
                       'testcases');
-                    assert.equal(subscriptions, 1);
+                    assert.notEqual(subscriptions.length, 0);
                   } else
                     subscriptionId = _.first(subscriptions).id;
 
@@ -86,7 +86,7 @@ describe(testSuite,
                   if (_.isEmpty(gitHubAccntInt)){
                     logger.warn('getAccountIntegrations 0 accInts which is not '
                       + 'expected, hence failing');
-                    assert.equal(gitHubAccntInt, 1);
+                    assert.notEqual(gitHubAccntInt.length, 0);
                   }
                   return done();
                 }
@@ -184,7 +184,7 @@ describe(testSuite,
                   var project = {};
                   if (_.isEmpty(projects)){
                     logger.warn('projects are empty, which is not expected');
-                    assert.equal(projects, 1);
+                    assert.notEqual(projects.length, 0);
                   }
                   project = _.findWhere(projects, {isPrivateRepository: false});
                   if (project)
@@ -302,7 +302,7 @@ describe(testSuite,
                 } else {
                   if (_.isEmpty(res)){
                     logger.warn('getResources returned 0 resources');
-                    assert.equal(res, 1);
+                    assert.notEqual(res.length, 0);
                   }
                   logger.debug("Successfully Got Resources");
                   return done();

--- a/tests/organization-owner/github/4-subscriptions/1.2.5.AddResource.js
+++ b/tests/organization-owner/github/4-subscriptions/1.2.5.AddResource.js
@@ -51,10 +51,11 @@ describe(testSuite,
                   if (subscriptions.status<200 || subscriptions.status>=299)
                     logger.warn("status is::",subscriptions.status);
 
-                  if (_.isEmpty(subscriptions))
+                  if (_.isEmpty(subscriptions)) {
                     logger.warn('No subscriptions found, skipping subsequent ' +
                       'testcases');
-                  else
+                    assert.equal(subscriptions, 1);
+                  } else
                     subscriptionId = _.first(subscriptions).id;
 
                   return done();
@@ -82,6 +83,11 @@ describe(testSuite,
                   return done();
                 } else {
                   gitHubAccntInt = _.first(accInts);
+                  if (_.isEmpty(gitHubAccntInt)){
+                    logger.warn('getAccountIntegrations 0 accInts which is not '
+                      + 'expected, hence failing');
+                    assert.equal(gitHubAccntInt, 1);
+                  }
                   return done();
                 }
               }
@@ -176,6 +182,10 @@ describe(testSuite,
                   return done();
                 } else {
                   var project = {};
+                  if (_.isEmpty(projects)){
+                    logger.warn('projects are empty, which is not expected');
+                    assert.equal(projects, 1);
+                  }
                   project = _.findWhere(projects, {isPrivateRepository: false});
                   if (project)
                     projectId = project.id;
@@ -290,6 +300,10 @@ describe(testSuite,
                   assert.equal(err, null);
                   return done();
                 } else {
+                  if (_.isEmpty(res)){
+                    logger.warn('getResources returned 0 resources');
+                    assert.equal(res, 1);
+                  }
                   logger.debug("Successfully Got Resources");
                   return done();
                 }

--- a/tests/organization-owner/github/4-subscriptions/1.2.6.ResourceModal.js
+++ b/tests/organization-owner/github/4-subscriptions/1.2.6.ResourceModal.js
@@ -45,7 +45,7 @@ describe(testSuite,
                 } else {
                   if (_.isEmpty(res)){
                     logger.warn('syncRepo resource is not present');
-                    assert.equal(res, 1);
+                    assert.notEqual(res.length, 0);
                   }
                   resource = _.first(res);
                   return done();

--- a/tests/organization-owner/github/4-subscriptions/1.2.6.ResourceModal.js
+++ b/tests/organization-owner/github/4-subscriptions/1.2.6.ResourceModal.js
@@ -43,6 +43,10 @@ describe(testSuite,
                   assert.equal(err, null);
                   return done();
                 } else {
+                  if (_.isEmpty(res)){
+                    logger.warn('syncRepo resource is not present');
+                    assert.equal(res, 1);
+                  }
                   resource = _.first(res);
                   return done();
                 }
@@ -78,6 +82,8 @@ describe(testSuite,
         it('Get Versions By ResourceId',
           function (done) {
             this.timeout(0);
+
+            if (!resource) return done();
 
             var query = util.format(
               'resourceIds=%s&subscriptionIds=%s&limit=%s&skip=%s', resource.id,

--- a/tests/organization-owner/github/4-subscriptions/1.2.7.ParamsModal.js
+++ b/tests/organization-owner/github/4-subscriptions/1.2.7.ParamsModal.js
@@ -43,7 +43,7 @@ describe(testSuite,
                 } else {
                   if (_.isEmpty(res)){
                     logger.warn('syncRepo resource is not present');
-                    assert.equal(res, 1);
+                    assert.notEqual(res.length, 0);
                   }
                   resource = _.first(res);
                   return done();

--- a/tests/organization-owner/github/4-subscriptions/1.2.7.ParamsModal.js
+++ b/tests/organization-owner/github/4-subscriptions/1.2.7.ParamsModal.js
@@ -41,6 +41,10 @@ describe(testSuite,
                   assert.equal(err, null);
                   return done();
                 } else {
+                  if (_.isEmpty(res)){
+                    logger.warn('syncRepo resource is not present');
+                    assert.equal(res, 1);
+                  }
                   resource = _.first(res);
                   return done();
                 }
@@ -53,6 +57,7 @@ describe(testSuite,
           function (done) {
             this.timeout(0);
 
+            if (!resource) return done();
             var query = util.format(
               'resourceIds=%s&subscriptionIds=%s&sortBy=id&limit=1', resource.id,
               resource.subscriptionId);

--- a/tests/organization-owner/github/4-subscriptions/1.2.8.pipelinesCtrl.js
+++ b/tests/organization-owner/github/4-subscriptions/1.2.8.pipelinesCtrl.js
@@ -47,10 +47,11 @@ describe(testSuite,
                   if (subscriptions.status<200 || subscriptions.status>=299)
                     logger.warn("status is::",subscriptions.status);
 
-                  if (_.isEmpty(subscriptions))
+                  if (_.isEmpty(subscriptions)) {
                     logger.warn('No subscriptions found, skipping subsequent ' +
                       'testcases');
-                  else
+                    assert.equal(subscriptions, 1);
+                  } else
                     subscriptionId = _.first(subscriptions).id;
 
                   return done();
@@ -105,6 +106,10 @@ describe(testSuite,
                   assert.equal(err, null);
                   return done();
                 } else {
+                  if (_.isEmpty(resources)){
+                    logger.warn('getResources returned 0 resources');
+                    assert.equal(resources, 1);
+                  }
                   jobsVm = _.where(resources, {"isJob": true});
                   resourcesVm = _.where(resources, {"isJob": false});
                   resourcesById = _.indexBy(resources, 'id');
@@ -240,6 +245,7 @@ describe(testSuite,
           function (done) {
             this.timeout(0);
 
+            if (_.isEmpty(resourcesVm)) return done();
             async.each(resourcesVm,
               function (resource, nextResource) {
                 var query = util.format('resourceIds=%s&sortBy=id&limit=1',
@@ -273,7 +279,7 @@ describe(testSuite,
 
             var query = util.format('subscriptionIds=%s',subscriptionId);
             shippable.getProjects(query,
-              function (err) {
+              function (err, projs) {
                 if (err) {
                   isTestFailed = true;
                   var testCase =
@@ -282,6 +288,11 @@ describe(testSuite,
                       testSuiteDesc, err);
                   testCaseErrors.push(testCase);
                   assert.equal(err, null);
+                  return done();
+                }
+                if (_.isEmpty(projs)) {
+                  logger.warn('No projects found');
+                  assert.equal(projs, 1);
                 }
                 return done();
               }

--- a/tests/organization-owner/github/4-subscriptions/1.2.8.pipelinesCtrl.js
+++ b/tests/organization-owner/github/4-subscriptions/1.2.8.pipelinesCtrl.js
@@ -50,7 +50,7 @@ describe(testSuite,
                   if (_.isEmpty(subscriptions)) {
                     logger.warn('No subscriptions found, skipping subsequent ' +
                       'testcases');
-                    assert.equal(subscriptions, 1);
+                    assert.notEqual(subscriptions.length, 0);
                   } else
                     subscriptionId = _.first(subscriptions).id;
 
@@ -108,7 +108,7 @@ describe(testSuite,
                 } else {
                   if (_.isEmpty(resources)){
                     logger.warn('getResources returned 0 resources');
-                    assert.equal(resources, 1);
+                    assert.notEqual(resources.length, 0);
                   }
                   jobsVm = _.where(resources, {"isJob": true});
                   resourcesVm = _.where(resources, {"isJob": false});
@@ -292,7 +292,7 @@ describe(testSuite,
                 }
                 if (_.isEmpty(projs)) {
                   logger.warn('No projects found');
-                  assert.equal(projs, 1);
+                  assert.notEqual(projs.length, 0);
                 }
                 return done();
               }

--- a/tests/organization-owner/github/4-subscriptions/1.2.9.JobModalCtrl.js
+++ b/tests/organization-owner/github/4-subscriptions/1.2.9.JobModalCtrl.js
@@ -51,10 +51,11 @@ describe(testSuite,
                   if (subscriptions.status<200 || subscriptions.status>=299)
                     logger.warn("status is::",subscriptions.status);
 
-                  if (_.isEmpty(subscriptions))
+                  if (_.isEmpty(subscriptions)) {
                     logger.warn('No subscriptions found, skipping subsequent ' +
                       'testcases');
-                  else
+                    assert.equal(subscriptions, 1);
+                  } else
                     subscriptionId = _.first(subscriptions).id;
 
                   return done();
@@ -82,6 +83,10 @@ describe(testSuite,
                   assert.equal(err, null);
                   return done();
                 } else {
+                  if (_.isEmpty(resources)){
+                    logger.warn('getResources returned 0 resources');
+                    assert.equal(resources, 1);
+                  }
                   jobsVm = _.where(resources, {"isJob": true});
                   return done();
                 }

--- a/tests/organization-owner/github/4-subscriptions/1.2.9.JobModalCtrl.js
+++ b/tests/organization-owner/github/4-subscriptions/1.2.9.JobModalCtrl.js
@@ -54,7 +54,7 @@ describe(testSuite,
                   if (_.isEmpty(subscriptions)) {
                     logger.warn('No subscriptions found, skipping subsequent ' +
                       'testcases');
-                    assert.equal(subscriptions, 1);
+                    assert.notEqual(subscriptions.length, 0);
                   } else
                     subscriptionId = _.first(subscriptions).id;
 
@@ -85,7 +85,7 @@ describe(testSuite,
                 } else {
                   if (_.isEmpty(resources)){
                     logger.warn('getResources returned 0 resources');
-                    assert.equal(resources, 1);
+                    assert.notEqual(resources.length, 0);
                   }
                   jobsVm = _.where(resources, {"isJob": true});
                   return done();

--- a/tests/organization-owner/github/4-subscriptions/1.2.91.JobConsoleCtrl.js
+++ b/tests/organization-owner/github/4-subscriptions/1.2.91.JobConsoleCtrl.js
@@ -82,7 +82,7 @@ describe(testSuite,
                 } else {
                   if (_.isEmpty(resources)){
                     logger.warn('getResources returned 0 resources');
-                    assert.notEqual(subscriptions.length, 0);
+                    assert.notEqual(resources.length, 0);
                   }
                   jobsVm = _.where(resources, {"isJob": true});
                   return done();

--- a/tests/organization-owner/github/4-subscriptions/1.2.91.JobConsoleCtrl.js
+++ b/tests/organization-owner/github/4-subscriptions/1.2.91.JobConsoleCtrl.js
@@ -48,10 +48,11 @@ describe(testSuite,
                   if (subscriptions.status<200 || subscriptions.status>=299)
                     logger.warn("status is::",subscriptions.status);
 
-                  if (_.isEmpty(subscriptions))
+                  if (_.isEmpty(subscriptions)) {
                     logger.warn('No subscriptions found, skipping subsequent ' +
                       'testcases');
-                  else
+                    assert.equal(subscriptions, 1);
+                  } else
                     subscriptionId = _.first(subscriptions).id;
 
                   return done();
@@ -79,6 +80,10 @@ describe(testSuite,
                   assert.equal(err, null);
                   return done();
                 } else {
+                  if (_.isEmpty(resources)){
+                    logger.warn('getResources returned 0 resources');
+                    assert.equal(resources, 1);
+                  }
                   jobsVm = _.where(resources, {"isJob": true});
                   return done();
                 }

--- a/tests/organization-owner/github/4-subscriptions/1.2.91.JobConsoleCtrl.js
+++ b/tests/organization-owner/github/4-subscriptions/1.2.91.JobConsoleCtrl.js
@@ -51,7 +51,7 @@ describe(testSuite,
                   if (_.isEmpty(subscriptions)) {
                     logger.warn('No subscriptions found, skipping subsequent ' +
                       'testcases');
-                    assert.equal(subscriptions, 1);
+                    assert.notEqual(subscriptions.length, 0);
                   } else
                     subscriptionId = _.first(subscriptions).id;
 
@@ -82,7 +82,7 @@ describe(testSuite,
                 } else {
                   if (_.isEmpty(resources)){
                     logger.warn('getResources returned 0 resources');
-                    assert.equal(resources, 1);
+                    assert.notEqual(subscriptions.length, 0);
                   }
                   jobsVm = _.where(resources, {"isJob": true});
                   return done();

--- a/tests/organization-owner/github/4-subscriptions/1.2.92.JobTraceCtrl.js
+++ b/tests/organization-owner/github/4-subscriptions/1.2.92.JobTraceCtrl.js
@@ -44,10 +44,11 @@ describe(testSuite,
                   if (subscriptions.status<200 || subscriptions.status>=299)
                     logger.warn("status is::",subscriptions.status);
 
-                  if (_.isEmpty(subscriptions))
+                  if (_.isEmpty(subscriptions)) {
                     logger.warn('No subscriptions found, skipping subsequent ' +
                       'testcases');
-                  else
+                    assert.equal(subscriptions, 1);
+                  } else
                     subscriptionId = _.first(subscriptions).id;
 
                   return done();
@@ -175,6 +176,10 @@ function _getResources(bag, done) {
         assert.equal(err, null);
         return done();
       } else {
+        if (_.isEmpty(resources)){
+          logger.warn('getResources returned 0 resources');
+          assert.equal(resources, 1);
+        }
         resource = _.first(_.where(resources, {"isJob": true}));
 
         if (resource.lastVersionId)

--- a/tests/organization-owner/github/4-subscriptions/1.2.92.JobTraceCtrl.js
+++ b/tests/organization-owner/github/4-subscriptions/1.2.92.JobTraceCtrl.js
@@ -47,7 +47,7 @@ describe(testSuite,
                   if (_.isEmpty(subscriptions)) {
                     logger.warn('No subscriptions found, skipping subsequent ' +
                       'testcases');
-                    assert.equal(subscriptions, 1);
+                    assert.notEqual(subscriptions.length, 0);
                   } else
                     subscriptionId = _.first(subscriptions).id;
 
@@ -178,7 +178,7 @@ function _getResources(bag, done) {
       } else {
         if (_.isEmpty(resources)){
           logger.warn('getResources returned 0 resources');
-          assert.equal(resources, 1);
+          assert.notEqual(resources.length, 0);
         }
         resource = _.first(_.where(resources, {"isJob": true}));
 

--- a/tests/organization-owner/github/4-subscriptions/1.2.93.DeleteResource.js
+++ b/tests/organization-owner/github/4-subscriptions/1.2.93.DeleteResource.js
@@ -49,7 +49,7 @@ describe(testSuite,
                   if (_.isEmpty(subscriptions)) {
                     logger.warn('No subscriptions found, skipping subsequent ' +
                       'testcases');
-                    assert.equal(subscriptions, 1);
+                    assert.notEqual(subscriptions.length, 0);
                   } else
                     subscriptionId = _.first(subscriptions).id;
 

--- a/tests/organization-owner/github/4-subscriptions/1.2.93.DeleteResource.js
+++ b/tests/organization-owner/github/4-subscriptions/1.2.93.DeleteResource.js
@@ -46,10 +46,11 @@ describe(testSuite,
                   if (subscriptions.status<200 || subscriptions.status>=299)
                     logger.warn("status is::",subscriptions.status);
 
-                  if (_.isEmpty(subscriptions))
+                  if (_.isEmpty(subscriptions)) {
                     logger.warn('No subscriptions found, skipping subsequent ' +
                       'testcases');
-                  else
+                    assert.equal(subscriptions, 1);
+                  } else
                     subscriptionId = _.first(subscriptions).id;
 
                   return done();

--- a/tests/organization-owner/github/5-projects/1.2.01.EnableAProject.js
+++ b/tests/organization-owner/github/5-projects/1.2.01.EnableAProject.js
@@ -47,7 +47,7 @@ describe('Enable Project',
                   if (_.isEmpty(subscriptions)) {
                     logger.warn('No subscriptions found, skipping subsequent ' +
                       'testcases');
-                    assert.equal(subscriptions, 1);
+                    assert.notEqual(subscriptions.length, 0);
                   } else
                     subscriptionId = _.first(subscriptions).id;
 
@@ -84,7 +84,7 @@ describe('Enable Project',
                   var project = {};
                   if (_.isEmpty(projects)){
                     logger.warn('No Projects found');
-                    assert.equal(projects, 1);
+                    assert.notEqual(projects.length, 0);
                   }
                   project = _.findWhere(projects, {isPrivateRepository: false});
                   projectId = project.id;

--- a/tests/organization-owner/github/5-projects/1.2.01.EnableAProject.js
+++ b/tests/organization-owner/github/5-projects/1.2.01.EnableAProject.js
@@ -44,10 +44,11 @@ describe('Enable Project',
                   if (subscriptions.status<200 || subscriptions.status>=299)
                     logger.warn("status is::",subscriptions.status);
 
-                  if (_.isEmpty(subscriptions))
+                  if (_.isEmpty(subscriptions)) {
                     logger.warn('No subscriptions found, skipping subsequent ' +
                       'testcases');
-                  else
+                    assert.equal(subscriptions, 1);
+                  } else
                     subscriptionId = _.first(subscriptions).id;
 
                   nconf.set('shiptest-GITHUB_ORG_1:subscriptionId', subscriptionId);
@@ -81,6 +82,10 @@ describe('Enable Project',
                   return done();
                 } else {
                   var project = {};
+                  if (_.isEmpty(projects)){
+                    logger.warn('No Projects found');
+                    assert.equal(projects, 1);
+                  }
                   project = _.findWhere(projects, {isPrivateRepository: false});
                   projectId = project.id;
                   nconf.set('shiptest-GITHUB_ORG_1:projectId',projectId);

--- a/tests/organization-owner/github/5-projects/1.2.04.Encrypt.js
+++ b/tests/organization-owner/github/5-projects/1.2.04.Encrypt.js
@@ -43,10 +43,11 @@ describe(testSuite,
                   if (subscriptions.status<200 || subscriptions.status>=299)
                     logger.warn("status is::",subscriptions.status);
 
-                  if (_.isEmpty(subscriptions))
+                  if (_.isEmpty(subscriptions)) {
                     logger.warn('No subscriptions found, skipping subsequent ' +
                       'testcases');
-                  else
+                    assert.equal(subscriptions, 1);
+                  } else
                     subscriptionId = _.first(subscriptions).id;
 
                   projectId = nconf.get("shiptest-GITHUB_ORG_1:projectId");

--- a/tests/organization-owner/github/5-projects/1.2.04.Encrypt.js
+++ b/tests/organization-owner/github/5-projects/1.2.04.Encrypt.js
@@ -46,7 +46,7 @@ describe(testSuite,
                   if (_.isEmpty(subscriptions)) {
                     logger.warn('No subscriptions found, skipping subsequent ' +
                       'testcases');
-                    assert.equal(subscriptions, 1);
+                    assert.notEqual(subscriptions.length, 0);
                   } else
                     subscriptionId = _.first(subscriptions).id;
 

--- a/tests/organization-owner/github/5-projects/1.2.17.select-systemMachineImages.js
+++ b/tests/organization-owner/github/5-projects/1.2.17.select-systemMachineImages.js
@@ -74,10 +74,11 @@ describe(testSuite,
                   if (subscriptions.status<200 || subscriptions.status>=299)
                     logger.warn("status is::",subscriptions.status);
 
-                  if (_.isEmpty(subscriptions))
+                  if (_.isEmpty(subscriptions)) {
                     logger.warn('No subscriptions found, skipping subsequent ' +
                       'testcases');
-                  else
+                    assert.equal(subscriptions, 1);
+                  } else
                     subscriptionId = _.first(subscriptions).id;
 
                   return done();

--- a/tests/organization-owner/github/5-projects/1.2.17.select-systemMachineImages.js
+++ b/tests/organization-owner/github/5-projects/1.2.17.select-systemMachineImages.js
@@ -77,7 +77,7 @@ describe(testSuite,
                   if (_.isEmpty(subscriptions)) {
                     logger.warn('No subscriptions found, skipping subsequent ' +
                       'testcases');
-                    assert.equal(subscriptions, 1);
+                    assert.notEqual(subscriptions.length, 0);
                   } else
                     subscriptionId = _.first(subscriptions).id;
 

--- a/tests/organization-owner/github/6-subscriptionNodes/1.2.01.tabNodesCtrl.js
+++ b/tests/organization-owner/github/6-subscriptionNodes/1.2.01.tabNodesCtrl.js
@@ -50,7 +50,7 @@ describe(testSuite,
                   if (_.isEmpty(subscriptions)) {
                     logger.warn('No subscriptions found, skipping subsequent ' +
                       'testcases');
-                    assert.equal(subscriptions, 1);
+                    assert.notEqual(subscriptions.length, 0);
                   } else
                     subscriptionId = _.first(subscriptions).id;
 

--- a/tests/organization-owner/github/6-subscriptionNodes/1.2.01.tabNodesCtrl.js
+++ b/tests/organization-owner/github/6-subscriptionNodes/1.2.01.tabNodesCtrl.js
@@ -46,7 +46,14 @@ describe(testSuite,
                 } else {
                   if (subscriptions.status<200 || subscriptions.status>=299)
                     logger.warn("status is::",subscriptions.status);
-                  subscriptionId = _.first(subscriptions).id;
+
+                  if (_.isEmpty(subscriptions)) {
+                    logger.warn('No subscriptions found, skipping subsequent ' +
+                      'testcases');
+                    assert.equal(subscriptions, 1);
+                  } else
+                    subscriptionId = _.first(subscriptions).id;
+
                   return done();
                 }
               }
@@ -57,6 +64,8 @@ describe(testSuite,
         it('get Subscription State By Id',
           function (done) {
             this.timeout(0);
+
+            if (!subscriptionId) return done();
 
             shippable.getSubscriptionStateById(subscriptionId,
               function(err, subscriptionState) {
@@ -168,6 +177,7 @@ describe(testSuite,
           function (done) {
             this.timeout(0);
             if (!hostChangeAllowed) return done();
+            if (!subscriptionId) return done();
 
             var update = {};
 

--- a/tests/organization-owner/github/6-subscriptionNodes/1.2.02.AddNewNode.js
+++ b/tests/organization-owner/github/6-subscriptionNodes/1.2.02.AddNewNode.js
@@ -46,7 +46,13 @@ describe(testSuite,
                 } else {
                   if (subscriptions.status<200 || subscriptions.status>=299)
                     logger.warn("status is::",subscriptions.status);
-                  subscriptionId = _.first(subscriptions).id;
+
+                  if (_.isEmpty(subscriptions)) {
+                    logger.warn('No subscriptions found, skipping subsequent ' +
+                      'testcases');
+                    assert.equal(subscriptions, 1);
+                  } else
+                    subscriptionId = _.first(subscriptions).id;
                   return done();
                 }
               }
@@ -57,6 +63,8 @@ describe(testSuite,
         it('get Subscription State By Id',
           function (done) {
             this.timeout(0);
+
+            if (!subscriptionId) return done();
 
             shippable.getSubscriptionStateById(subscriptionId,
               function(err, subscriptionState) {
@@ -85,6 +93,7 @@ describe(testSuite,
             this.timeout(0);
 
             if (isDynamicNode) return done();
+            if (!subscriptionId) return done();
 
             var newNode = {
               subscriptionId: subscriptionId,
@@ -123,6 +132,7 @@ describe(testSuite,
             this.timeout(0);
 
             if (isDynamicNode) return done();
+            if (!clusterNodeId) return don();
 
             shippable.getClusterNodeById(clusterNodeId,
               function(err) {

--- a/tests/organization-owner/github/6-subscriptionNodes/1.2.02.AddNewNode.js
+++ b/tests/organization-owner/github/6-subscriptionNodes/1.2.02.AddNewNode.js
@@ -50,7 +50,7 @@ describe(testSuite,
                   if (_.isEmpty(subscriptions)) {
                     logger.warn('No subscriptions found, skipping subsequent ' +
                       'testcases');
-                    assert.equal(subscriptions, 1);
+                    assert.notEqual(subscriptions.length, 0);
                   } else
                     subscriptionId = _.first(subscriptions).id;
                   return done();

--- a/tests/organization-owner/github/6-subscriptionNodes/1.2.03.NodeConsoles.js
+++ b/tests/organization-owner/github/6-subscriptionNodes/1.2.03.NodeConsoles.js
@@ -47,7 +47,7 @@ describe(testSuite,
                   if (_.isEmpty(subscriptions)) {
                     logger.warn('No subscriptions found, skipping subsequent ' +
                       'testcases');
-                    assert.equal(subscriptions, 1);
+                    assert.notEqual(subscriptions.length, 0);
                   } else
                     subscriptionId = _.first(subscriptions).id;
                   return done();

--- a/tests/organization-owner/github/6-subscriptionNodes/1.2.03.NodeConsoles.js
+++ b/tests/organization-owner/github/6-subscriptionNodes/1.2.03.NodeConsoles.js
@@ -43,7 +43,13 @@ describe(testSuite,
                 } else {
                   if (subscriptions.status<200 || subscriptions.status>=299)
                     logger.warn("status is::",subscriptions.status);
-                  subscriptionId = _.first(subscriptions).id;
+
+                  if (_.isEmpty(subscriptions)) {
+                    logger.warn('No subscriptions found, skipping subsequent ' +
+                      'testcases');
+                    assert.equal(subscriptions, 1);
+                  } else
+                    subscriptionId = _.first(subscriptions).id;
                   return done();
                 }
               }

--- a/tests/organization-owner/github/6-subscriptionNodes/1.2.04.NodeStats.js
+++ b/tests/organization-owner/github/6-subscriptionNodes/1.2.04.NodeStats.js
@@ -47,7 +47,7 @@ describe(testSuite,
                   if (_.isEmpty(subscriptions)) {
                     logger.warn('No subscriptions found, skipping subsequent ' +
                       'testcases');
-                    assert.equal(subscriptions, 1);
+                    assert.notEqual(subscriptions.length, 0);
                   } else
                     subscriptionId = _.first(subscriptions).id;
                   return done();

--- a/tests/organization-owner/github/6-subscriptionNodes/1.2.04.NodeStats.js
+++ b/tests/organization-owner/github/6-subscriptionNodes/1.2.04.NodeStats.js
@@ -43,7 +43,13 @@ describe(testSuite,
                 } else {
                   if (subscriptions.status<200 || subscriptions.status>=299)
                     logger.warn("status is::",subscriptions.status);
-                  subscriptionId = _.first(subscriptions).id;
+
+                  if (_.isEmpty(subscriptions)) {
+                    logger.warn('No subscriptions found, skipping subsequent ' +
+                      'testcases');
+                    assert.equal(subscriptions, 1);
+                  } else
+                    subscriptionId = _.first(subscriptions).id;
                   return done();
                 }
               }

--- a/tests/organization-owner/github/6-subscriptionNodes/1.2.05.NodeSettings.js
+++ b/tests/organization-owner/github/6-subscriptionNodes/1.2.05.NodeSettings.js
@@ -48,7 +48,7 @@ describe(testSuite,
                   if (_.isEmpty(subscriptions)) {
                     logger.warn('No subscriptions found, skipping subsequent ' +
                       'testcases');
-                    assert.equal(subscriptions, 1);
+                    assert.notEqual(subscriptions.length, 0);
                   } else
                     subscriptionId = _.first(subscriptions).id;
                   return done();

--- a/tests/organization-owner/github/6-subscriptionNodes/1.2.05.NodeSettings.js
+++ b/tests/organization-owner/github/6-subscriptionNodes/1.2.05.NodeSettings.js
@@ -44,7 +44,13 @@ describe(testSuite,
                 } else {
                   if (subscriptions.status<200 || subscriptions.status>=299)
                     logger.warn("status is::",subscriptions.status);
-                  subscriptionId = _.first(subscriptions).id;
+
+                  if (_.isEmpty(subscriptions)) {
+                    logger.warn('No subscriptions found, skipping subsequent ' +
+                      'testcases');
+                    assert.equal(subscriptions, 1);
+                  } else
+                    subscriptionId = _.first(subscriptions).id;
                   return done();
                 }
               }
@@ -186,6 +192,8 @@ describe(testSuite,
         it('Change to Dynamic Node',
           function (done) {
             this.timeout(0);
+
+            if (!subscriptionId) return done();
 
             var update = {
               nodeTypeCode: 7001

--- a/tests/organization-owner/github/7-integrations/1.2.addIntegration.js
+++ b/tests/organization-owner/github/7-integrations/1.2.addIntegration.js
@@ -41,7 +41,13 @@ describe('Add Integrations',
                 } else {
                   if (subscriptions.status<200 || subscriptions.status>=299)
                     logger.warn("status is::",subscriptions.status);
-                  subscriptionId = _.first(subscriptions).id;
+
+                  if (_.isEmpty(subscriptions)) {
+                    logger.warn('No subscriptions found, skipping subsequent ' +
+                      'testcases');
+                    assert.equal(subscriptions, 1);
+                  } else
+                    subscriptionId = _.first(subscriptions).id;
                   return done();
                 }
               }
@@ -1175,6 +1181,9 @@ describe('Add Integrations',
           function (done) {
             this.timeout(0);
             var shippable = new Shippable(config.apiToken);
+            if (!subscriptionId) return done();
+            if (_.isEmpty(accountIntegrations)) return done();
+
             async.each(accountIntegrations,
               function (accInt, nextAccInt) {
                 var body = {

--- a/tests/organization-owner/github/7-integrations/1.2.addIntegration.js
+++ b/tests/organization-owner/github/7-integrations/1.2.addIntegration.js
@@ -45,7 +45,7 @@ describe('Add Integrations',
                   if (_.isEmpty(subscriptions)) {
                     logger.warn('No subscriptions found, skipping subsequent ' +
                       'testcases');
-                    assert.equal(subscriptions, 1);
+                    assert.notEqual(subscriptions.length, 0);
                   } else
                     subscriptionId = _.first(subscriptions).id;
                   return done();


### PR DESCRIPTION
https://github.com/Shippable/bat/issues/429

locally verified:
```
deepika@deepika-ThinkPad-X250:~/Desktop/shippable/bat$ npm run test-organizationOwner

> BAT@0.0.1 test-organizationOwner /home/deepika/Desktop/shippable/bat
> ./node_modules/mocha/bin/mocha -S tests/organization-owner/github/**/*.js



  Setup for accounts
    ✓ Should start setup (51ms)

  Edit email with valid and invalid email address
    1.2.accounts_editEmail - Edit email in accounts page
      ✓ Edit email with valid email address (47ms)
      ✓ Edit email contains dot in the address field
      ✓ Edit Email contains dot with subdomain
      ✓ Plus sign is considered valid character
      ✓ Quotes around email is considered valid
      ✓ Digits in address are valid
      ✓ Dash in domain name is valid
      ✓ Underscore in the address field is valid
      ✓ .name is valid Top Level Domain name
      ✓ Dot in Top Level Domain name also considered valid
      ✓ Unicode char as address
      ✓ .web is a valid top level domain
      ✓ Dash in address field is valid
    1.2.accounts_editEmail - Edit email in accounts page
2017-03-17T08:57:05.314Z - warn: PUT call to http://localhost:50000/accounts/58cb86b101f7c019008fb131? returned status 404 with error 404
      ✓ Missing @ sign and domain
2017-03-17T08:57:05.325Z - warn: PUT call to http://localhost:50000/accounts/58cb86b101f7c019008fb131? returned status 404 with error 404
      ✓ Domain is invalid IP address
2017-03-17T08:57:05.343Z - warn: PUT call to http://localhost:50000/accounts/58cb86b101f7c019008fb131? returned status 404 with error 404
      ✓ Square bracket around IP address is considered invalid
2017-03-17T08:57:05.352Z - warn: PUT call to http://localhost:50000/accounts/58cb86b101f7c019008fb131? returned status 404 with error 404
      ✓ Garbage
2017-03-17T08:57:05.371Z - warn: PUT call to http://localhost:50000/accounts/58cb86b101f7c019008fb131? returned status 404 with error 404
      ✓ Missing username
2017-03-17T08:57:05.380Z - warn: PUT call to http://localhost:50000/accounts/58cb86b101f7c019008fb131? returned status 404 with error 404
      ✓ Encoded html within email is invalid
2017-03-17T08:57:05.403Z - warn: PUT call to http://localhost:50000/accounts/58cb86b101f7c019008fb131? returned status 404 with error 404
      ✓ Missing @
2017-03-17T08:57:05.413Z - warn: PUT call to http://localhost:50000/accounts/58cb86b101f7c019008fb131? returned status 404 with error 404
      ✓ Two @ sign
2017-03-17T08:57:05.434Z - warn: PUT call to http://localhost:50000/accounts/58cb86b101f7c019008fb131? returned status 404 with error 404
      ✓ Leading dot in address is not allowed
2017-03-17T08:57:05.442Z - warn: PUT call to http://localhost:50000/accounts/58cb86b101f7c019008fb131? returned status 404 with error 404
      ✓ Trailing dot in address is not allowed
2017-03-17T08:57:05.467Z - warn: PUT call to http://localhost:50000/accounts/58cb86b101f7c019008fb131? returned status 404 with error 404
      ✓ Multiple dots
2017-03-17T08:57:05.477Z - warn: PUT call to http://localhost:50000/accounts/58cb86b101f7c019008fb131? returned status 404 with error 404
      ✓ Text followed email is not allowed
2017-03-17T08:57:05.495Z - warn: PUT call to http://localhost:50000/accounts/58cb86b101f7c019008fb131? returned status 404 with error 404
      ✓ Missing top level domain (.com/.net/.org/etc)
2017-03-17T08:57:05.504Z - warn: PUT call to http://localhost:50000/accounts/58cb86b101f7c019008fb131? returned status 404 with error 404
      ✓ Leading dash in front of domain is invalid
2017-03-17T08:57:05.523Z - warn: PUT call to http://localhost:50000/accounts/58cb86b101f7c019008fb131? returned status 404 with error 404
      ✓ Invalid IP format
2017-03-17T08:57:05.532Z - warn: PUT call to http://localhost:50000/accounts/58cb86b101f7c019008fb131? returned status 404 with error 404
      ✓ Multiple dot in the domain portion is invalid
    Should run after above test suites
      ✓ Edit email with actual email address
      ✓ Creating Github Issue if test cases failed

  1.2_sync_accountByid - Sync Account for organization owner
    ✓ Sync Account for organization owner (47ms)

  Add Tokens with different name
    1.2.accounts_AddToken - Add Tokens in account settings page
      ✓ Enter token name with 150 characters (77ms)
      ✓ Enter token name with less than 150 characters (78ms)
      ✓ Enter a - z; A - Z; (98ms)
      ✓ Enter numbers (59ms)
      ✓ Enter special characters (47ms)
      ✓ Enter Alphanumeric values (43ms)
      ✓ Enter the name with blank spaces (82ms)
      ✓ Enter special characters,numbers,alphabets
    1.2.accounts_AddToken - Add Tokens in account settings page
2017-03-17T08:57:06.148Z - warn: POST call to http://localhost:50000/accountTokens returned status 404 with error 404
      ✓ Enter token name with more than 150 characters
2017-03-17T08:57:06.186Z - warn: POST call to http://localhost:50000/accountTokens returned status 409 with error 409
      ✓ Enter the name already exists (39ms)
    Should run after above test suites
      ✓ Creating Github Issue if test cases failed

  1.2.API Tokens - ApiTokens
    Getting list of ApiTokens
      ✓ Get List of API Tokens
    delete ApiTokens
      ✓ delete ApiTokens (67ms)
    Create GitHub issue if failed
      ✓ Creating Github Issue if test cases failed

  1.2 - Account Cards
    Getting list of AccountCards
2017-03-17T08:57:07.248Z - warn: GET call to http://localhost:50000/accountCards? returned status 400 with error 400
      1) Get List of AccountCards
    delete AccountCards
      ✓ delete AccountCards
    Create GitHub issue if failed
      ✓ Creating Github Issue if test cases failed (1065ms)

  Edit email with valid and invalid email address in technical contact
    Get subscriptions
      ✓ Organization-Owner-github-getSubscription
    1.2 - Edit technical contact in subscription settings page
      ✓ Edit email with valid email address (117ms)
      ✓ Edit email contains dot in the address field (95ms)
      ✓ Edit Email contains dot with subdomain (90ms)
      ✓ Plus sign is considered valid character (105ms)
      ✓ Quotes around email is considered valid (86ms)
      ✓ Digits in address are valid (88ms)
      ✓ Dash in domain name is valid (88ms)
      ✓ Underscore in the address field is valid (86ms)
      ✓ .name is valid Top Level Domain name (202ms)
      ✓ Dot in Top Level Domain name also considered valid (128ms)
      ✓ Unicode char as address (126ms)
      ✓ .web is a valid top level domain (87ms)
      ✓ Dash in address field is valid (90ms)
    1.2 - Edit technical contact in subscription settings page
2017-03-17T08:57:09.749Z - warn: PUT call to http://localhost:50000/subscriptions/58cb86b501f7c019008fb134 returned status 404 with error 404
      ✓ Missing @ sign and domain
2017-03-17T08:57:09.762Z - warn: PUT call to http://localhost:50000/subscriptions/58cb86b501f7c019008fb134 returned status 404 with error 404
      ✓ Domain is invalid IP address
2017-03-17T08:57:09.785Z - warn: PUT call to http://localhost:50000/subscriptions/58cb86b501f7c019008fb134 returned status 404 with error 404
      ✓ Square bracket around IP address is considered invalid
2017-03-17T08:57:09.796Z - warn: PUT call to http://localhost:50000/subscriptions/58cb86b501f7c019008fb134 returned status 404 with error 404
      ✓ Garbage
2017-03-17T08:57:09.813Z - warn: PUT call to http://localhost:50000/subscriptions/58cb86b501f7c019008fb134 returned status 404 with error 404
      ✓ Missing username
2017-03-17T08:57:09.828Z - warn: PUT call to http://localhost:50000/subscriptions/58cb86b501f7c019008fb134 returned status 404 with error 404
      ✓ Encoded html within email is invalid
2017-03-17T08:57:09.849Z - warn: PUT call to http://localhost:50000/subscriptions/58cb86b501f7c019008fb134 returned status 404 with error 404
      ✓ Missing @
2017-03-17T08:57:09.860Z - warn: PUT call to http://localhost:50000/subscriptions/58cb86b501f7c019008fb134 returned status 404 with error 404
      ✓ Two @ sign
2017-03-17T08:57:09.883Z - warn: PUT call to http://localhost:50000/subscriptions/58cb86b501f7c019008fb134 returned status 404 with error 404
      ✓ Leading dot in address is not allowed
2017-03-17T08:57:09.893Z - warn: PUT call to http://localhost:50000/subscriptions/58cb86b501f7c019008fb134 returned status 404 with error 404
      ✓ Trailing dot in address is not allowed
2017-03-17T08:57:09.912Z - warn: PUT call to http://localhost:50000/subscriptions/58cb86b501f7c019008fb134 returned status 404 with error 404
      ✓ Multiple dots
2017-03-17T08:57:09.922Z - warn: PUT call to http://localhost:50000/subscriptions/58cb86b501f7c019008fb134 returned status 404 with error 404
      ✓ Text followed email is not allowed
2017-03-17T08:57:09.941Z - warn: PUT call to http://localhost:50000/subscriptions/58cb86b501f7c019008fb134 returned status 404 with error 404
      ✓ Missing top level domain (.com/.net/.org/etc)
2017-03-17T08:57:09.951Z - warn: PUT call to http://localhost:50000/subscriptions/58cb86b501f7c019008fb134 returned status 404 with error 404
      ✓ Leading dash in front of domain is invalid
2017-03-17T08:57:09.976Z - warn: PUT call to http://localhost:50000/subscriptions/58cb86b501f7c019008fb134 returned status 404 with error 404
      ✓ Invalid IP format
2017-03-17T08:57:09.986Z - warn: PUT call to http://localhost:50000/subscriptions/58cb86b501f7c019008fb134 returned status 404 with error 404
      ✓ Multiple dot in the domain portion is invalid
    Should run after above test suites
      ✓ Creating Github Issue if test cases failed

  Edit email with valid and invalid email address
    1.2- Edit Billing email in subcriptions page
      ✓ Organization-Owner-github-getSubscription
      ✓ Edit email with valid email address (86ms)
      ✓ Edit email contains dot in the address field (139ms)
      ✓ Edit Email contains dot with subdomain (148ms)
      ✓ Plus sign is considered valid character (145ms)
      ✓ Quotes around email is considered valid (135ms)
      ✓ Digits in address are valid (133ms)
      ✓ Dash in domain name is valid (202ms)
      ✓ Underscore in the address field is valid (170ms)
      ✓ .name is valid Top Level Domain name (166ms)
      ✓ Dot in Top Level Domain name also considered valid (180ms)
      ✓ Unicode char as address (94ms)
      ✓ .web is a valid top level domain (89ms)
      ✓ Dash in address field is valid (87ms)
    1.2- Edit Billing email in subcriptions page
2017-03-17T08:57:11.813Z - warn: PUT call to http://localhost:50000/subscriptions/58cb86b501f7c019008fb134 returned status 404 with error 404
      ✓ Missing @ sign and domain
2017-03-17T08:57:11.825Z - warn: PUT call to http://localhost:50000/subscriptions/58cb86b501f7c019008fb134 returned status 404 with error 404
      ✓ Domain is invalid IP address
2017-03-17T08:57:11.848Z - warn: PUT call to http://localhost:50000/subscriptions/58cb86b501f7c019008fb134 returned status 404 with error 404
      ✓ Square bracket around IP address is considered invalid
2017-03-17T08:57:11.857Z - warn: PUT call to http://localhost:50000/subscriptions/58cb86b501f7c019008fb134 returned status 404 with error 404
      ✓ Garbage
2017-03-17T08:57:11.873Z - warn: PUT call to http://localhost:50000/subscriptions/58cb86b501f7c019008fb134 returned status 404 with error 404
      ✓ Missing username
2017-03-17T08:57:11.889Z - warn: PUT call to http://localhost:50000/subscriptions/58cb86b501f7c019008fb134 returned status 404 with error 404
      ✓ Encoded html within email is invalid
2017-03-17T08:57:11.913Z - warn: PUT call to http://localhost:50000/subscriptions/58cb86b501f7c019008fb134 returned status 404 with error 404
      ✓ Missing @
2017-03-17T08:57:11.939Z - warn: PUT call to http://localhost:50000/subscriptions/58cb86b501f7c019008fb134 returned status 404 with error 404
      ✓ Two @ sign
2017-03-17T08:57:11.954Z - warn: PUT call to http://localhost:50000/subscriptions/58cb86b501f7c019008fb134 returned status 404 with error 404
      ✓ Leading dot in address is not allowed
2017-03-17T08:57:11.973Z - warn: PUT call to http://localhost:50000/subscriptions/58cb86b501f7c019008fb134 returned status 404 with error 404
      ✓ Trailing dot in address is not allowed
2017-03-17T08:57:11.982Z - warn: PUT call to http://localhost:50000/subscriptions/58cb86b501f7c019008fb134 returned status 404 with error 404
      ✓ Multiple dots
2017-03-17T08:57:11.996Z - warn: PUT call to http://localhost:50000/subscriptions/58cb86b501f7c019008fb134 returned status 404 with error 404
      ✓ Text followed email is not allowed
2017-03-17T08:57:12.010Z - warn: PUT call to http://localhost:50000/subscriptions/58cb86b501f7c019008fb134 returned status 404 with error 404
      ✓ Missing top level domain (.com/.net/.org/etc)
2017-03-17T08:57:12.019Z - warn: PUT call to http://localhost:50000/subscriptions/58cb86b501f7c019008fb134 returned status 404 with error 404
      ✓ Leading dash in front of domain is invalid
2017-03-17T08:57:12.038Z - warn: PUT call to http://localhost:50000/subscriptions/58cb86b501f7c019008fb134 returned status 404 with error 404
      ✓ Invalid IP format
2017-03-17T08:57:12.047Z - warn: PUT call to http://localhost:50000/subscriptions/58cb86b501f7c019008fb134 returned status 404 with error 404
      ✓ Multiple dot in the domain portion is invalid
    Should run after above test suites
      ✓ Creating Github Issue if test cases failed

  Reset in subscription settings page
    1.2 - Reset in subscription settings page
      ✓ Organization-Owner-github-getSubscription
      ✓ Reset subscription from subscription settings pages (1164ms)
    Should run after above test suites
      ✓ Creating Github Issue if test cases failed

  1.2 - subscription settings - encrypt and decrypt
    Encrypt and Decrypt
      ✓ Organization-Owner-github-getSubscription
      ✓ Enter encrypt value with alphabets and encrypt (59ms)
      ✓ Enter encrypt value with numbers and encrypt (63ms)
      ✓ Enter encrypt value with alphanumeric and encrypt (53ms)
      ✓ Enter encrypt with special characters and encrypt (45ms)
      ✓ Enter encrypt value with blank spaces and encrypt (41ms)
      ✓ Encrypt value with special characters,numbers,alphabets and encrypt (43ms)
      ✓ Encrypt value with foo: fubu (48ms)
      ✓ Encrypt value with foo= fubu (57ms)
    Create GitHub issue if failed
      ✓ Creating Github Issue if test cases failed

  1.2 - Add a Resource
    Create Github subscriptionIntegration
      ✓ Organization-Owner-github-getSubscription
      ✓ Get github AccountIntegartion
      ✓ Add github subscriptionIntegration (79ms)
    Create New Resource
      ✓ Get SubscriptionIntegrations (43ms)
      ✓ Get Projects (38ms)
      ✓ Get Project Resources
      ✓ Get ProjectById (3154ms)
      ✓ Add a resource (8037ms)
      ✓ get resources
    Should run after above test suites
      ✓ Creating Github Issue if test cases failed

  1.2 - Resource Modal
    Resource Modal Controller
      ✓ get syncRepo resource
      ✓ Get SubscriptionIntegrations (55ms)
      ✓ Get Versions By ResourceId (47ms)
    Should run after above test suites
      ✓ Creating Github Issue if test cases failed

  1.2 - Params Modal
    Resource Modal Controller
      ✓ get syncRepo resource (50ms)
      ✓ Get Versions By ResourceId (49ms)
      ✓ post Version (284ms)
    Should run after above test suites
      ✓ Creating Github Issue if test cases failed

  1.2 - Pipelines Controller
    Resource Modal Controller
      ✓ Organization-Owner-github-getSubscription (73ms)
      ✓ Get Subscription By Id (81ms)
      ✓ get resources (113ms)
      ✓ get Job Dependencies (78ms)
      ✓ get Build Status By SubscriptionId (139ms)
      ✓ get Version By Id (84ms)
      ✓ get Resource By Id (98ms)
      ✓ get resources (156ms)
      ✓ get versions for each resource (47ms)
      ✓ Get Projects
      ✓ Get Inflight Builds
    Should run after above test suites
      ✓ Creating Github Issue if test cases failed

  1.2 - Job Modal
    Job Modal Controller
      ✓ Organization-Owner-github-getSubscription
      ✓ get resources
      ✓ get Builds By resourceId
      ✓ get Build By id
      ✓ get BuildJobs
      ✓ get builds
      ✓ get Versions for all builds
      ✓ trigger New Build By ResourceId (39ms)
      ✓ put Build By Id (74ms)
      ✓ get Build By Id
      ✓ pause Run Workflow (74ms)
      ✓ unPause Run Workflow (87ms)
    Should run after above test suites
      ✓ Creating Github Issue if test cases failed

  1.2 - Job Console
    Job Consoles Controller
      ✓ Organization-Owner-github-getSubscription
      ✓ get resources
      ✓ get Builds By resourceId
      ✓ get BuildJobs
      ✓ get BuildJobConsoles By BuildJobId (42ms)
    Should run after above test suites
      ✓ Creating Github Issue if test cases failed

  1.2 - Job Trace 
    Job Trace Controller
      ✓ Organization-Owner-github-getSubscription
      ✓ Get resources (6185ms)
      ✓ get versions (58ms)
      ✓ get resources
    Should run after above test suites
      ✓ Creating Github Issue if test cases failed

  1.2 - Delete Resource
    Delete Resource
      ✓ Organization-Owner-github-getSubscription
      ✓ get resources
      ✓ Get Builds (14168ms)
      ✓ soft delete resource (142ms)
      ✓ hard delete resource (2040ms)
      ✓ delete Github subscriptionIntegration (139ms)
    Should run after above test suites
      ✓ Creating Github Issue if test cases failed

  Enable Project
    1.2 - Enable Project
      ✓ Organization-Owner-github-getSubscription
      ✓ Get Projects (86ms)
      ✓ Enable Project (5527ms)
    Should run after above test suites
      ✓ Creating Github Issue if test cases failed

  Pause Project
    1.2 - Pause a Project
      ✓ Pause Project (94ms)
      ✓ Resume Project (132ms)
    Should run after above test suites
      ✓ Creating Github Issue if test cases failed

  Clear Cache
    1.2 - Clear cache
      ✓ Clear Cache
    Should run after above test suites
      ✓ Creating Github Issue if test cases failed

  1.2 - Project settings - encrypt and decrypt
    Encrypt and Decrypt
      ✓ Organization-Owner-github-getSubscription
      ✓ Enter encrypt value with alphabets and encrypt (56ms)
      ✓ Enter encrypt value with numbers and encrypt (46ms)
      ✓ Enter encrypt value with alphanumeric and encrypt (44ms)
      ✓ Enter encrypt with special characters and encrypt (43ms)
      ✓ Enter encrypt value with blank spaces and encrypt (45ms)
      ✓ Encrypt value with special characters,numbers,alphabets and encrypt (42ms)
      ✓ Encrypt value with foo: fubu (44ms)
      ✓ Encrypt value with foo= fubu (44ms)
    Create GitHub issue if failed
      ✓ Creating Github Issue if test cases failed

  Reset in project settings page
    1.2 - Reset in project settings page
      ✓ Reset project from project settings pages (3959ms)
    Should run after above test suites
      ✓ Creating Github Issue if test cases failed

  Project RunsConfig
    1.2 - Project RunsConfig
      ✓ Get ProjectOwnerAccounts (54ms)
      ✓ Set OwnerAccountIdWorkflow
      ✓ Automate Low Coverage Alert for value 10
      ✓ Automate Low Coverage Alert for value 50
      ✓ Automate Low Coverage Alert for value 99
      ✓ Automate Low Coverage Alert for value 40 (47ms)
      ✓ Custom Timeout for valid value 10 mins (600000 ms) (96ms)
      ✓ Custom Timeout for valid value 10.5 mins (630000 ms) (39ms)
2017-03-17T08:58:00.638Z - warn: PUT call to http://localhost:50000/projects/58cb86b701f7c019008fb14f returned status 400 with error 400
      ✓ Custom Timeout for invalid value 10000000 ms (38ms)
2017-03-17T08:58:00.648Z - warn: PUT call to http://localhost:50000/projects/58cb86b701f7c019008fb14f returned status 400 with error 400
      ✓ Custom Timeout for invalid value ee
2017-03-17T08:58:00.671Z - warn: PUT call to http://localhost:50000/projects/58cb86b701f7c019008fb14f returned status 400 with error 400
      ✓ Custom Timeout for invalid value 0 ms
      ✓ Disable Run Parallel Jobs
      ✓ Enable Run Parallel Jobs
      ✓ Enable Consolidate Reports
      ✓ Disable Consolidate Reports
      ✓ Enable PullRequestBuilds
      ✓ Disable PullRequestBuilds
      ✓ Enable CommitBuilds
      ✓ Disable CommitBuilds
      ✓ Enable TagBuilds (42ms)
      ✓ Disable TagBuilds (38ms)
      ✓ Clear ProjectTimeout
      ✓ Enable Serialization
      ✓ Disable Serialization
      ✓ Enable ReleaseBuilds
      ✓ Disable ReleaseBuilds
      ✓ Get ProjectsById
      ✓ Add SerializedBranch
      ✓ Remove SerializedBranch
      ✓ SaveBranchFilter
      ✓ SaveRunFilter for commit only
      ✓ SaveRunFilter for commit and pull requests
    Should run after above test suites
      ✓ Creating Github Issue if test cases failed

  Projects Dashboard
    1.2 - Projects Dashboard
      ✓ Trigger new build request (4427ms)
      ✓ Get inflight runs (48ms)
      ✓ Cancel run (79ms)
      ✓ Get branch run status (177ms)
      ✓ Get run by id (56ms)
    Should run after above test suites
      ✓ Creating Github Issue if test cases failed

  Project History
    1.2 - Project History
      ✓ Get ProjectsById (48ms)
      ✓ Get Runs
      ✓ Trigger new build request (1792ms)
      ✓ Get RunsById (61ms)
      ✓ Delete Run (370ms)
      ✓ Trigger new build request (4108ms)
      ✓ Get JobStatesMap
      ✓ Get Runs (40ms)
    Should run after above test suites
      ✓ Creating Github Issue if test cases failed

  Subscriptions Dashboard
    1.2 - Subscriptions Dashboard
      ✓ Get Projects (43ms)
      ✓ Get Run Status By SubscriptionId (128ms)
      ✓ Trigger New Build (4092ms)
      ✓ Get inflight runs (62ms)
      ✓ wireDeleteRunGetTop (51ms)
      ✓ Put buildById
      ✓ Cancel run (151ms)
      ✓ Get runById (64ms)
      ✓ Get Run Status By SubId (83ms)
    Should run after above test suites
      ✓ Creating Github Issue if test cases failed

  Subscription History
    1.2 - Subscription History
      ✓ Get SubscriptionsById
      ✓ Get ProjectsById (42ms)
      ✓ Get Runs
      ✓ Trigger new build request (1846ms)
      ✓ Get RunsById (55ms)
      ✓ Delete Run (320ms)
    Should run after above test suites
      ✓ Creating Github Issue if test cases failed

  Home Dashboard
    1.2 - Home Dashboard
      ✓ Get ProjectAccounts
      ✓ Get Enabled Projects
      ✓ Get Provider
      ✓ Get Run Status By accountId (46ms)
      ✓ Get inflight runs
      ✓ Cancel run
      ✓ Get RunById
      ✓ Get Runs for runFilter for commit and pull requests
      ✓ Get Runs for runFilter for commit only
    Should run after above test suites
      ✓ Creating Github Issue if test cases failed

  Runs Console
    1.2 - Runs Console
      ✓ Get Jobs
      ✓ Get JobConsoles By JobId (55ms)
      ✓ Trigger New Build (4145ms)
      ✓ Get runById (41ms)
      ✓ Cancel run
    Should run after above test suites
      ✓ Creating Github Issue if test cases failed

  Runs Tests
    1.2 - Runs Tests
      ✓ Get Jobs (42ms)
      ✓ Get Job Test Reports (65ms)
    Should run after above test suites
      ✓ Creating Github Issue if test cases failed

  Runs Script
    1.2 - Runs Script
      ✓ Get Jobs (50ms)
      ✓ Get Jobs Script (41ms)
    Should run after above test suites
      ✓ Creating Github Issue if test cases failed

  Runs Coverage
    1.2 - Runs Coverage
      ✓ Get Runs
      ✓ Get Jobs
      ✓ Get Coverage Reports
      ✓ Get Previous Runs
      ✓ Get Complete Jobs
      ✓ Get Reports By JobId
    Should run after above test suites
      ✓ Creating Github Issue if test cases failed

  Disable Project
    1.2 - Disable Project
      ✓ Disable Project (3567ms)
    Should run after above test suites
      ✓ Creating Github Issue if test cases failed

  1.2 - Machine Images
    select Machine Images
      ✓ Get systemMachineImages
      ✓ Organization-Owner-github-getSubscription
      ✓ put systemMachineImageId to subscriptions (135ms)
    Create GitHub issue if failed
      ✓ Creating Github Issue if test cases failed

  1.2 - Nodes
    Nodes Controller
      ✓ Organization-Owner-github-getSubscription
      ✓ get Subscription State By Id (81ms)
      ✓ get ClusterNodes
      ✓ get Jobs
      ✓ get BuildJobs
      ✓ Change to Custom Node (97ms)
    Should run after above test suites
      ✓ Creating Github Issue if test cases failed

  1.2 - Add New Nodes
    Add New Nodes Controller
      ✓ Organization-Owner-github-getSubscription
      ✓ get Subscription State By Id (55ms)
      ✓ Add a custom node (136ms)
      ✓ get ClusterNode ById
    Should run after above test suites
      ✓ Creating Github Issue if test cases failed

  1.2 - Node Consoles
    ClusterNode Consoles Controller
      ✓ Organization-Owner-github-getSubscription
      ✓ get ClusterNodes
      ✓ get ClusterNode Console By ClusterNodeId (49ms)
    Should run after above test suites
      ✓ Creating Github Issue if test cases failed

  1.2 - Node Stats
    ClusterNode Stats Controller
      ✓ Organization-Owner-github-getSubscription
      ✓ get ClusterNodes
      ✓ get ClusterNode Stats (78ms)
    Should run after above test suites
      ✓ Creating Github Issue if test cases failed

  1.2 - Node Settings
    ClusterNode Settings Controller
      ✓ Organization-Owner-github-getSubscription
      ✓ get ClusterNodes
      ✓ get ClusterNode ById
      ✓ Edit ClusterNode ById (44ms)
      ✓ Reset ClusterNode
      ✓ delete ClusterNodeById (92ms)
      ✓ Change to Dynamic Node (122ms)
    Should run after above test suites
      ✓ Creating Github Issue if test cases failed

  Add Integrations
    Get github Account Integration
      ✓ Organization-Owner-github-getSubscription
      ✓ Get github AccountIntegartion
    1.2 - Add Integrations
      ✓ Add Gitlab AccountIntegration (62ms)
      ✓ Add Amazon ECR AccountIntegration (56ms)
2017-03-17T08:58:29.235Z - warn: POST call to http://localhost:50000/accountIntegrations returned status 404 with error 404
      2) Add AWS AccountIntegration
      ✓ Add ACS AccountIntegration (83ms)
      ✓ Add bitbucket AccountIntegration (69ms)
      ✓ Add ddc AccountIntegration (72ms)
      ✓ Add docker AccountIntegration (64ms)
      ✓ Add event trigger AccountIntegration (82ms)
      ✓ Add gcr AccountIntegration (89ms)
      ✓ Add gke AccountIntegration (115ms)
      ✓ Add hipchat AccountIntegration (83ms)
      ✓ Add private docker registry AccountIntegration (56ms)
      ✓ Add generic webhook AccountIntegration (57ms)
      ✓ Add Slack AccountIntegration (56ms)
2017-03-17T08:58:30.096Z - warn: POST call to http://localhost:50000/accountIntegrations returned status 404 with error 404
      3) Add AWS_IAM AccountIntegration
      ✓ Add Docker Cloud AccountIntegration (75ms)
      ✓ Add Docker Trusted Registry AccountIntegration (71ms)
      ✓ Add Github Enterprise AccountIntegration (75ms)
      ✓ Add Joyent Triton Public Cloud AccountIntegration (94ms)
      ✓ Add PEM Key AccountIntegration (89ms)
      ✓ Add Quay.io AccountIntegration (73ms)
      ✓ Add SSH Key AccountIntegration (107ms)
    1.2 - Add Integrations
      ✓ Add subscriptionIntegrations (1163ms)
    Should run after above test suites
      ✓ Creating Github Issue if test cases failed (894ms)

  1.2 - Get Integrations
    Getting list of AccountIntegartions
      ✓ Get List of AccountIntegartions (67ms)
    Edit account Integrations
      ✓ Edit Gitlab Account Intgeration (78ms)
      4) Edit AWS Account Intgeration
      ✓ Edit Amazon ECR Account Intgeration (74ms)
      ✓ Edit ACS Account Intgeration (112ms)
      ✓ Edit bitbucket Account Intgeration (94ms)
      ✓ Edit ddc Account Intgeration (91ms)
      ✓ Edit docker Account Intgeration (81ms)
      ✓ Edit event trigger Account Intgeration (83ms)
      ✓ Edit gcr Account Intgeration (73ms)
      ✓ Edit gke Account Intgeration (87ms)
      ✓ Edit hipchat Account Intgeration (76ms)
      ✓ Edit private docker registry Account Intgeration (77ms)
      ✓ Edit generic webhook event trigger Account Intgeration (78ms)
      ✓ Edit slack Account Intgeration (87ms)
      5) Edit AWS_IAM Account Intgeration
      ✓ Edit Docker_Cloud Account Intgeration (128ms)
      ✓ Edit Docker_trusted_registry Account Intgeration (73ms)
      ✓ Edit Github-Enterprise Account Intgeration (89ms)
      ✓ Edit Joyent-Triton-Public-Cloud Account Intgeration (115ms)
      ✓ Edit PEM-Key Account Intgeration (121ms)
      ✓ Edit Quay.io Account Intgeration (85ms)
      ✓ Edit SSH-Key Account Intgeration (93ms)
    Getting the list of subscriptionIntegrations
      ✓ Get the list of subscriptionIntegrations
    Edit subscription Integration
      ✓ Edit all subscription Intgerations (962ms)
    delete AccountIntegrations With Dependencies
2017-03-17T08:58:36.045Z - warn: DELETE call to http://localhost:50000/accountIntegrations/58cba53601f7c019008fb224 returned status 400 with error 400
2017-03-17T08:58:36.055Z - warn: DELETE call to http://localhost:50000/accountIntegrations/58cba53601f7c019008fb223 returned status 400 with error 400
2017-03-17T08:58:36.071Z - warn: DELETE call to http://localhost:50000/accountIntegrations/58cba53601f7c019008fb222 returned status 400 with error 400
2017-03-17T08:58:36.089Z - warn: DELETE call to http://localhost:50000/accountIntegrations/58cba53601f7c019008fb221 returned status 400 with error 400
2017-03-17T08:58:36.090Z - warn: DELETE call to http://localhost:50000/accountIntegrations/58cba53601f7c019008fb21f returned status 400 with error 400
2017-03-17T08:58:36.125Z - warn: DELETE call to http://localhost:50000/accountIntegrations/58cba53601f7c019008fb21e returned status 400 with error 400
2017-03-17T08:58:36.126Z - warn: DELETE call to http://localhost:50000/accountIntegrations/58cba53601f7c019008fb21d returned status 400 with error 400
2017-03-17T08:58:36.127Z - warn: DELETE call to http://localhost:50000/accountIntegrations/58cba53501f7c019008fb21c returned status 400 with error 400
2017-03-17T08:58:36.129Z - warn: DELETE call to http://localhost:50000/accountIntegrations/58cba53601f7c019008fb220 returned status 400 with error 400
2017-03-17T08:58:36.149Z - warn: DELETE call to http://localhost:50000/accountIntegrations/58cba53501f7c019008fb21b returned status 400 with error 400
2017-03-17T08:58:36.154Z - warn: DELETE call to http://localhost:50000/accountIntegrations/58cba53501f7c019008fb21a returned status 400 with error 400
2017-03-17T08:58:36.162Z - warn: DELETE call to http://localhost:50000/accountIntegrations/58cba53501f7c019008fb219 returned status 400 with error 400
2017-03-17T08:58:36.163Z - warn: DELETE call to http://localhost:50000/accountIntegrations/58cba53501f7c019008fb218 returned status 400 with error 400
2017-03-17T08:58:36.164Z - warn: DELETE call to http://localhost:50000/accountIntegrations/58cba53501f7c019008fb217 returned status 400 with error 400
2017-03-17T08:58:36.177Z - warn: DELETE call to http://localhost:50000/accountIntegrations/58cba53501f7c019008fb216 returned status 400 with error 400
2017-03-17T08:58:36.183Z - warn: DELETE call to http://localhost:50000/accountIntegrations/58cba53501f7c019008fb215 returned status 400 with error 400
2017-03-17T08:58:36.185Z - warn: DELETE call to http://localhost:50000/accountIntegrations/58cba53501f7c019008fb214 returned status 400 with error 400
2017-03-17T08:58:36.186Z - warn: DELETE call to http://localhost:50000/accountIntegrations/58cba53501f7c019008fb213 returned status 400 with error 400
2017-03-17T08:58:36.187Z - warn: DELETE call to http://localhost:50000/accountIntegrations/58cba53501f7c019008fb212 returned status 400 with error 400
2017-03-17T08:58:36.189Z - warn: DELETE call to http://localhost:50000/accountIntegrations/58cba53501f7c019008fb211 returned status 400 with error 400
2017-03-17T08:58:36.190Z - warn: DELETE call to http://localhost:50000/accountIntegrations/58cba4cf01f7c019008fb1e1 returned status 400 with error 400
      ✓ delete AccountIntegrations (586ms)
    Delete subscriptionIntegrations
      ✓ Delete SubscriptionIntegrations (975ms)
    delete AccountIntegrations
      ✓ delete AccountIntegrations (650ms)
    Create GitHub issue if failed
      ✓ Creating Github Issue if test cases failed
```