### PR TITLE
Changes log level to info

### DIFF
--- a/_common/shippable/Adapter.js
+++ b/_common/shippable/Adapter.js
@@ -1347,7 +1347,7 @@ function _performCall(bag, next) {
 
             return;
           } else {
-            logger.warn(util.format('%s returned status %s with error %s',
+            logger.info(util.format('%s returned status %s with error %s',
               bag.who, res && res.statusCode, err));
             bag.err = err;
           }


### PR DESCRIPTION
Changed log level from warn to info as this will reduce a lot of clutter in bvt logs.
If a test is failing bvt will tell us, we don't need warn info on that.