### PR TITLE
use isEmpty to check whether resource is present or not

### DIFF
--- a/tests/organization-owner/github/4-subscriptions/1.2.6.ResourceModal.js
+++ b/tests/organization-owner/github/4-subscriptions/1.2.6.ResourceModal.js
@@ -59,7 +59,7 @@ describe(testSuite,
           function (done) {
             this.timeout(0);
 
-            if (!resource) return done();
+            if (_.isEmpty(resource)) return done();
 
             var subIntId = resource.subscriptionIntegrationId;
             shippable.getSubscriptionIntegrationById(subIntId,
@@ -83,7 +83,7 @@ describe(testSuite,
           function (done) {
             this.timeout(0);
 
-            if (!resource) return done();
+            if (_.isEmpty(resource)) return done();
 
             var query = util.format(
               'resourceIds=%s&subscriptionIds=%s&limit=%s&skip=%s', resource.id,

--- a/tests/organization-owner/github/4-subscriptions/1.2.7.ParamsModal.js
+++ b/tests/organization-owner/github/4-subscriptions/1.2.7.ParamsModal.js
@@ -57,7 +57,7 @@ describe(testSuite,
           function (done) {
             this.timeout(0);
 
-            if (!resource) return done();
+            if (_.isEmpty(resource)) return done();
             var query = util.format(
               'resourceIds=%s&subscriptionIds=%s&sortBy=id&limit=1', resource.id,
               resource.subscriptionId);
@@ -83,7 +83,7 @@ describe(testSuite,
           function (done) {
             this.timeout(0);
 
-            if (!resource) return done();
+            if (_.isEmpty(resource)) return done();
 
             var newVersion = {
               resourceId: resource.id,


### PR DESCRIPTION
If resource is not present, we are already failing it. The subsequent tests should be skipped, if resource not present.

bvt:
if here: `get Sync Repo` fails, we skip: `Get SubscriptionIntegrations`, `Get Versions By ResourceId` tests
```
1.2 - Resource Modal
    Resource Modal Controller
2017-03-21T12:42:16.816Z - warn: syncRepo resource is not present
      2) get syncRepo resource
2017-03-21T12:42:16.835Z - warn: GET call to https://rcapi.shippable.com/subscriptionIntegrations/undefined returned status 404 with error 404
      3) Get SubscriptionIntegrations
2017-03-21T12:42:16.853Z - warn: GET call to https://rcapi.shippable.com/versions?resourceIds=undefined&subscriptionIds=undefined&limit=100&skip=0 returned status 404 with error 404
      4) Get Versions By ResourceId
    Should run after above test suites
      ✓ Creating Github Issue if test cases failed (178ms)
  1.2 - Params Modal
    Resource Modal Controller
2017-03-21T12:42:17.056Z - warn: syncRepo resource is not present
      5) get syncRepo resource
2017-03-21T12:42:17.073Z - warn: GET call to https://rcapi.shippable.com/versions?resourceIds=undefined&subscriptionIds=undefined&sortBy=id&limit=1 returned status 404 with error 404
      6) Get Versions By ResourceId
2017-03-21T12:42:17.217Z - warn: POST call to https://rcapi.shippable.com/versions returned status 404 with error 404
      7) post Version
    Should run after above test suites
      ✓ Creating Github Issue if test cases failed (164ms)
```