### PR TITLE
fail bvt immedietly if any test case fails

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "test-tokenExchange": "./node_modules/mocha/bin/mocha tests/testTokenExchange.js",
     "test-getAccounts": "./node_modules/mocha/bin/mocha tests/getAccounts.js",
     "test-deleteAccounts": "./node_modules/mocha/bin/mocha tests/deleteAccount.js",
-    "test-organizationOwner": "./node_modules/mocha/bin/mocha -S tests/organization-owner/github/**/*.js"
+    "test-organizationOwner": "./node_modules/mocha/bin/mocha -S -b tests/organization-owner/github/**/*.js"
   },
   "author": "Avi Cavale <avi@shippable.com> (http://shippable.com/)",
   "dependencies": {


### PR DESCRIPTION
Locally verified:

```
...
..
2017-03-22T07:08:43.152Z - warn: PUT call to http://localhost:50000/subscriptions/58d0b1485390d40600dfe307 returned status 404 with error 404
      ✓ Multiple dot in the domain portion is invalid
    Should run after above test suites
      ✓ Creating Github Issue if test cases failed

  Edit email with valid and invalid email address
    1.2- Edit Billing email in subcriptions page
      ✓ Organization-Owner-github-getSubscription
      ✓ Edit email with valid email address (148ms)
      ✓ Edit email contains dot in the address field (75ms)
      ✓ Edit Email contains dot with subdomain (84ms)
      ✓ Plus sign is considered valid character (77ms)
      ✓ Quotes around email is considered valid (81ms)
      ✓ Digits in address are valid (78ms)
      ✓ Dash in domain name is valid (79ms)
      ✓ Underscore in the address field is valid (85ms)
      ✓ .name is valid Top Level Domain name (84ms)
      ✓ Dot in Top Level Domain name also considered valid (173ms)
      ✓ Unicode char as address (169ms)
      ✓ .web is a valid top level domain (89ms)
      ✓ Dash in address field is valid (129ms)
    1.2- Edit Billing email in subcriptions page
2017-03-22T07:08:44.663Z - warn: PUT call to http://localhost:50000/subscriptions/58d0b1485390d40600dfe307 returned status 404 with error 404
      ✓ Missing @ sign and domain (138ms)
2017-03-22T07:08:44.675Z - warn: PUT call to http://localhost:50000/subscriptions/58d0b1485390d40600dfe307 returned status 404 with error 404
      ✓ Domain is invalid IP address
2017-03-22T07:08:44.702Z - warn: PUT call to http://localhost:50000/subscriptions/58d0b1485390d40600dfe307 returned status 404 with error 404
      ✓ Square bracket around IP address is considered invalid
2017-03-22T07:08:44.718Z - warn: PUT call to http://localhost:50000/subscriptions/58d0b1485390d40600dfe307 returned status 404 with error 404
      ✓ Garbage
2017-03-22T07:08:44.730Z - warn: PUT call to http://localhost:50000/subscriptions/58d0b1485390d40600dfe307 returned status 404 with error 404
      ✓ Missing username
2017-03-22T07:08:44.752Z - warn: PUT call to http://localhost:50000/subscriptions/58d0b1485390d40600dfe307 returned status 404 with error 404
      ✓ Encoded html within email is invalid
2017-03-22T07:08:44.763Z - warn: PUT call to http://localhost:50000/subscriptions/58d0b1485390d40600dfe307 returned status 404 with error 404
      ✓ Missing @
2017-03-22T07:08:44.782Z - warn: PUT call to http://localhost:50000/subscriptions/58d0b1485390d40600dfe307 returned status 404 with error 404
      ✓ Two @ sign
2017-03-22T07:08:44.795Z - warn: PUT call to http://localhost:50000/subscriptions/58d0b1485390d40600dfe307 returned status 404 with error 404
      ✓ Leading dot in address is not allowed
2017-03-22T07:08:44.813Z - warn: PUT call to http://localhost:50000/subscriptions/58d0b1485390d40600dfe307 returned status 404 with error 404
      ✓ Trailing dot in address is not allowed
2017-03-22T07:08:44.824Z - warn: PUT call to http://localhost:50000/subscriptions/58d0b1485390d40600dfe307 returned status 404 with error 404
      ✓ Multiple dots
2017-03-22T07:08:44.843Z - warn: PUT call to http://localhost:50000/subscriptions/58d0b1485390d40600dfe307 returned status 404 with error 404
      ✓ Text followed email is not allowed
2017-03-22T07:08:44.854Z - warn: PUT call to http://localhost:50000/subscriptions/58d0b1485390d40600dfe307 returned status 404 with error 404
      ✓ Missing top level domain (.com/.net/.org/etc)
2017-03-22T07:08:44.874Z - warn: PUT call to http://localhost:50000/subscriptions/58d0b1485390d40600dfe307 returned status 404 with error 404
      ✓ Leading dash in front of domain is invalid
2017-03-22T07:08:44.886Z - warn: PUT call to http://localhost:50000/subscriptions/58d0b1485390d40600dfe307 returned status 404 with error 404
      ✓ Invalid IP format
2017-03-22T07:08:44.904Z - warn: PUT call to http://localhost:50000/subscriptions/58d0b1485390d40600dfe307 returned status 404 with error 404
      ✓ Multiple dot in the domain portion is invalid
    Should run after above test suites
      ✓ Creating Github Issue if test cases failed

  Reset in subscription settings page
    1.2 - Reset in subscription settings page
      ✓ Organization-Owner-github-getSubscription
2017-03-22T07:08:49.064Z - warn: POST call to http://localhost:50000/subscriptions/58d0b1485390d40600dfe307/reset returned status 400 with error 400
      1) Reset subscription from subscription settings pages


  113 passing (10s)
  1 failing

  1) Reset in subscription settings page 1.2 - Reset in subscription settings page Reset subscription from subscription settings pages:
     Uncaught AssertionError: expected 400 to equal null
      at tests/organization-owner/github/4-subscriptions/1.2.3.resetSubscription.js:77:26
      at _common/shippable/Adapter.js:1259:9
      at node_modules/async/dist/async.js:3853:9
      at node_modules/async/dist/async.js:484:16
      at replenish (node_modules/async/dist/async.js:1025:25)
      at iterateeCallback (node_modules/async/dist/async.js:1015:17)
      at node_modules/async/dist/async.js:988:16
      at node_modules/async/dist/async.js:3850:13
      at apply (node_modules/async/dist/async.js:41:25)
      at node_modules/async/dist/async.js:76:12
      at _parseBody (_common/shippable/Adapter.js:1384:10)
      at node_modules/async/dist/async.js:3845:9
      at replenish (node_modules/async/dist/async.js:1030:17)
      at iterateeCallback (node_modules/async/dist/async.js:1015:17)
      at node_modules/async/dist/async.js:988:16
      at node_modules/async/dist/async.js:3850:13
      at apply (node_modules/async/dist/async.js:41:25)
      at node_modules/async/dist/async.js:76:12
      at Request._callback (_common/shippable/Adapter.js:1362:9)
      at Request.self.callback (node_modules/request/request.js:186:22)
      at Request.<anonymous> (node_modules/request/request.js:1081:10)
      at IncomingMessage.<anonymous> (node_modules/request/request.js:1001:12)
      at endReadableNT (_stream_readable.js:934:12)
      at _combinedTickCallback (internal/process/next_tick.js:74:11)
      at process._tickCallback (internal/process/next_tick.js:98:9)




npm ERR! Linux 3.19.0-79-generic
npm ERR! argv "/usr/local/bin/node" "/usr/local/bin/npm" "run" "test-organizationOwner"
npm ERR! node v6.2.2
npm ERR! npm  v3.9.5
npm ERR! code ELIFECYCLE
npm ERR! BAT@0.0.1 test-organizationOwner: `./node_modules/mocha/bin/mocha -S -b tests/organization-owner/github/**/*.js`
npm ERR! Exit status 1
npm ERR! 
npm ERR! Failed at the BAT@0.0.1 test-organizationOwner script './node_modules/mocha/bin/mocha -S -b tests/organization-owner/github/**/*.js'.
npm ERR! Make sure you have the latest version of node.js and npm installed.
npm ERR! If you do, this is most likely a problem with the BAT package,
npm ERR! not with npm itself.
npm ERR! Tell the author that this fails on your system:
npm ERR!     ./node_modules/mocha/bin/mocha -S -b tests/organization-owner/github/**/*.js
npm ERR! You can get information on how to open an issue for this project with:
npm ERR!     npm bugs BAT
npm ERR! Or if that isn't available, you can get their info via:
npm ERR!     npm owner ls BAT
npm ERR! There is likely additional logging output above.

npm ERR! Please include the following file with any support request:
npm ERR!     /home/deepika/Desktop/shippable/bat/npm-debug.log
```