### PR TITLE
skip get versions for inconsistent jobs

### DIFF
--- a/tests/organization-owner/github/4-subscriptions/1.2.92.JobTraceCtrl.js
+++ b/tests/organization-owner/github/4-subscriptions/1.2.92.JobTraceCtrl.js
@@ -184,7 +184,8 @@ function _getResources(bag, done) {
 
         if (!resource.isConsistent) {
           bag.isStatusCompleted = true;
-          logger.warn('InConsistent resources wont have version.');
+          logger.warn(util.format('InConsistent resource: %s wont have version',
+            resource.name));
         }
 
         if (resource.lastVersionId)

--- a/tests/organization-owner/github/4-subscriptions/1.2.92.JobTraceCtrl.js
+++ b/tests/organization-owner/github/4-subscriptions/1.2.92.JobTraceCtrl.js
@@ -182,6 +182,11 @@ function _getResources(bag, done) {
         }
         resource = _.first(_.where(resources, {"isJob": true}));
 
+        if (!resource.isConsistent) {
+          bag.isStatusCompleted = true;
+          logger.warn('InConsistent resources wont have version.');
+        }
+
         if (resource.lastVersionId)
           bag.isStatusCompleted = true;
 

--- a/tests/organization-owner/github/4-subscriptions/1.2.92.JobTraceCtrl.js
+++ b/tests/organization-owner/github/4-subscriptions/1.2.92.JobTraceCtrl.js
@@ -191,6 +191,8 @@ function _getResources(bag, done) {
         if (resource.lastVersionId)
           bag.isStatusCompleted = true;
 
+        // If job is in processing state, then resouce will not have versionId,
+        // waiting until job gets a completed state.
         if (!bag.isStatusCompleted) {
           bag.timeoutLength *= 2;
           if (bag.timeoutLength > bag.timeoutLimit)


### PR DESCRIPTION
Some times, bvt gets struck at this test case:

```
 1.2 - Job Trace 
    Job Trace Controller
      ✓ Organization-Owner-github-getSubscription
```
This is happening coz, whenever job is inconsistent, there would be no version for that job.

I have tested locally:
My rSync job was inconsistent and it was struck. after adding the check, it passed.
```
   1.2 - Job Trace 
    Job Trace Controller
      ✓ Organization-Owner-github-getSubscription
2017-03-23T07:46:29.469Z - warn: InConsistent resource: sample_org_auto_test_master_rSync wont have version
      ✓ Get resources
2017-03-23T07:46:29.493Z - warn: GET call to http://localhost:50000/versions?versionIds=null returned status 404 with error 404
      3) get versions
      ✓ get resources
    Should run after above test suites
      ✓ Creating Github Issue if test cases failed (822ms)

  1.2 - Delete Resource
    Delete Resource
```